### PR TITLE
Metadata: MDUI support (+ misc fixes)

### DIFF
--- a/app/federationregistry/fr-config.groovy.example
+++ b/app/federationregistry/fr-config.groovy.example
@@ -93,6 +93,16 @@ aaf {
     metadata {
       federation = "aaf.edu.au"
 
+      // MDUI settings
+      mdui {
+        // Language to use for MDUIInfo elements as the xml:lang attribute
+        // (I.e., language the roleDescriptor displayName and Description are stored in)
+        lang = "en"
+        // Control whether render MDUI in metadata - off by default
+        displayName = false
+        description = false
+      }
+
       /* registration info - optional
       // website of your registration authority (federation)
       registrationAuthority = "https://www.federation.org/"

--- a/app/federationregistry/fr-config.groovy.example
+++ b/app/federationregistry/fr-config.groovy.example
@@ -129,7 +129,7 @@ aaf {
           attributeservice.uri = '$host:8443/idp/profile/SAML2/SOAP/AttributeQuery'
         }
         shib23 {
-          displayName = 'Shibboleth Identity Provider (2.3.x, 2.4.x)'
+          displayName = 'Shibboleth Identity Provider (2.3.x, 2.4.x, 3.0.x, 3.1.x)'
           selected = true
           entitydescriptor = '$host/idp/shibboleth'
           post.uri = '$host/idp/profile/SAML2/POST/SSO'

--- a/app/plugins/base/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/base/grails-app/conf/BuildConfig.groovy
@@ -42,6 +42,6 @@ grails.project.dependency.resolution = {
       exclude "spock-grails-support"
     }
     test ":resources:1.1.6"
-    provided ":greenmail:1.3.2"
+    provided ":greenmail:1.3.4"
   }
 }

--- a/app/plugins/export/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/export/grails-app/conf/BuildConfig.groovy
@@ -45,6 +45,6 @@ grails.project.dependency.resolution = {
       exclude "spock-grails-support"
     }
     test ":resources:1.1.6"
-    provided ":greenmail:1.3.2"
+    provided ":greenmail:1.3.4"
   }
 }

--- a/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
+++ b/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
@@ -397,8 +397,9 @@ class MetadataGenerationService implements InitializingBean {
   }
   
   def AttributeAuthorityDescriptorExtensions(builder, all, roleDescriptor) {
+    boolean isRegex = roleDescriptor.scope.startsWith('^') && roleDescriptor.scope.endsWith('$')
     builder.Extensions() {
-      builder."shibmd:Scope" (regexp:false, roleDescriptor.scope)
+      builder."shibmd:Scope" (regexp:isRegex, roleDescriptor.scope)
     } 
   }
   

--- a/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
+++ b/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
@@ -21,6 +21,10 @@ class MetadataGenerationService implements InitializingBean {
   def hasRegistrationAuthority
   def hasRegistrationPolicy
 
+  def mduiLang
+  def renderMDUIDisplayName
+  def renderMDUIDescription
+
   def void afterPropertiesSet() {
       // initialize registration info from grailsApplication.config
       registrationAuthority = grailsApplication.config.aaf.fr.metadata.registrationAuthority
@@ -29,6 +33,11 @@ class MetadataGenerationService implements InitializingBean {
 
       hasRegistrationAuthority = registrationAuthority && !registrationAuthority.isEmpty()
       hasRegistrationPolicy = registrationPolicy && registrationPolicyLang
+
+      // initialize MDUI info from grailsApplication.config
+      mduiLang = grailsApplication.config.aaf.fr.metadata.mdui.lang
+      renderMDUIDisplayName = grailsApplication.config.aaf.fr.metadata.mdui.displayName && mduiLang;
+      renderMDUIDescription = grailsApplication.config.aaf.fr.metadata.mdui.description && mduiLang;
   }
 
   def populateSchema(minimal, roleExtensions) {
@@ -37,6 +46,10 @@ class MetadataGenerationService implements InitializingBean {
     if (hasRegistrationAuthority && !minimal && roleExtensions) {
         namespaces['xmlns:mdrpi'] = 'urn:oasis:names:tc:SAML:metadata:rpi';
         namespaces["xsi:schemaLocation"] = namespaces["xsi:schemaLocation"] + " urn:oasis:names:tc:SAML:metadata:rpi saml-metadata-rpi-v1.0.xsd"
+    }
+    if ((renderMDUIDisplayName||renderMDUIDescription) && !minimal && roleExtensions) {
+        namespaces['xmlns:mdui'] = 'urn:oasis:names:tc:SAML:metadata:ui';
+        namespaces["xsi:schemaLocation"] = namespaces["xsi:schemaLocation"] + " urn:oasis:names:tc:SAML:metadata:ui saml-metadata-ui-v1.0.xsd"
     }
     namespaces
   }
@@ -380,16 +393,38 @@ class MetadataGenerationService implements InitializingBean {
     boolean isRegex = roleDescriptor.scope.startsWith('^') && roleDescriptor.scope.endsWith('$')
     builder.Extensions() {
       builder."shibmd:Scope" (regexp:isRegex, roleDescriptor.scope)
+      if ( (renderMDUIDisplayName && roleDescriptor.displayName) || (renderMDUIDescription && roleDescriptor.description) ) {
+        builder."mdui:UIInfo" {
+          if (renderMDUIDisplayName && roleDescriptor.displayName) {
+            localizedName(builder, "mdui:DisplayName", mduiLang, roleDescriptor.displayName)
+          }
+          if (renderMDUIDescription && roleDescriptor.description) {
+            localizedName(builder, "mdui:Description", mduiLang, roleDescriptor.description)
+          }
+        }
+      }
     }
   }
   
   def SPSSODescriptorExtensions(builder, all, spSSODescriptor) {
     def funcDiscoveryResponseServices = spSSODescriptor.discoveryResponseServices?.findAll{it.functioning()}
-    if(all || funcDiscoveryResponseServices) {
+    if(all || funcDiscoveryResponseServices ||
+            (renderMDUIDisplayName && spSSODescriptor.displayName) ||
+            (renderMDUIDescription && spSSODescriptor.description) ) {
       builder.Extensions() {
         spSSODescriptor.discoveryResponseServices?.sort{it.id}.each { endpoint ->
           if(all || endpoint.functioning() ) {
             builder."dsr:DiscoveryResponse"("xmlns:dsr":"urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol", Binding: endpoint.binding.uri, Location:endpoint.location, index:endpoint.index, isDefault:endpoint.isDefault)
+          }
+        }
+        if ( (renderMDUIDisplayName && spSSODescriptor.displayName) || (renderMDUIDescription && spSSODescriptor.description) ) {
+          builder."mdui:UIInfo" {
+            if (renderMDUIDisplayName && spSSODescriptor.displayName) {
+              localizedName(builder, "mdui:DisplayName", mduiLang, spSSODescriptor.displayName)
+            }
+            if (renderMDUIDescription && spSSODescriptor.description) {
+              localizedName(builder, "mdui:Description", mduiLang, spSSODescriptor.description)
+            }
           }
         }
       }
@@ -400,6 +435,16 @@ class MetadataGenerationService implements InitializingBean {
     boolean isRegex = roleDescriptor.scope.startsWith('^') && roleDescriptor.scope.endsWith('$')
     builder.Extensions() {
       builder."shibmd:Scope" (regexp:isRegex, roleDescriptor.scope)
+      if ( (renderMDUIDisplayName && roleDescriptor.displayName) || (renderMDUIDescription && roleDescriptor.description) ) {
+        builder."mdui:UIInfo" {
+          if (renderMDUIDisplayName && roleDescriptor.displayName) {
+            localizedName(builder, "mdui:DisplayName", mduiLang, roleDescriptor.displayName)
+          }
+          if (renderMDUIDescription && roleDescriptor.description) {
+            localizedName(builder, "mdui:Description", mduiLang, roleDescriptor.description)
+          }
+        }
+      }
     } 
   }
   

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorwmdui.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorwmdui.xml
@@ -1,0 +1,100 @@
+<EntitiesDescriptor xmlns='urn:oasis:names:tc:SAML:2.0:metadata' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion' xmlns:shibmd='urn:mace:shibboleth:metadata:1.0' xmlns:ds='http://www.w3.org/2000/09/xmldsig#' xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xsi:schemaLocation='urn:oasis:names:tc:SAML:2.0:metadata saml-schema-metadata-2.0.xsd urn:mace:shibboleth:metadata:1.0 shibboleth-metadata-1.0.xsd http://www.w3.org/2000/09/xmldsig# xmldsig-core-schema.xsd urn:oasis:names:tc:SAML:metadata:ui saml-metadata-ui-v1.0.xsd' ID='_20110825T013428Z' validUntil='2009-07-22T00:00:00Z' Name='some.test.name'>
+  <Extensions>
+    <shibmd:KeyAuthority xmlns:shibmd='urn:mace:shibboleth:metadata:1.0' VerifyDepth='5'>
+      <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
+        <ds:X509Data>
+          <ds:X509Certificate>
+MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
+BQUAMBkxFzAVBgNVBAMTDnZoby5hYWYuZWR1LmF1MB4XDTA5MDUwNDA2MTgyNVoX
+DTI5MDUwNDA2MTgyNVowGTEXMBUGA1UEAxMOdmhvLmFhZi5lZHUuYXUwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDWB4cjn/vxigCmLp1J4Y9OW84acUnO
+YFcb3piAy3fc+dhA6AVHCjLrh7tWRIycmcz5qqIbOFnS5qBqg/zBAAhpPGRHjJTd
+9J6iUN6bWXeaTTBAO9QDtYPt8iAymPFCgbr4lil5JuE9cg6uVgb2/RQlZqludxV6
+aUTbtJePJz5KAVMrlfHVguKjH5GpwVcBztMmtRgOPC37Ptyz9Wo/FxpkwpkZCmag
+tQUTBdSL1lr7ySW4CqH4QCgyplBJ2jOnG2IsGZ0TnCQ5cfNuB9Iw8uU5bBMiZvI+
+2xuDQV4KWyz3lbTHLPHk/Iw57/NdwOeKMLmmJRiRwuJJaOS4MNaPoWsbAgMBAAGj
+YzBhMEAGA1UdEQQ5MDeCDnZoby5hYWYuZWR1LmF1hiVodHRwczovL3Zoby5hYWYu
+ZWR1LmF1L2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBTRu0lIvmQAgPzWEMhtz7Gm
+eYWEqDANBgkqhkiG9w0BAQUFAAOCAQEAUwiq3jCuhENSyehA2AjhmfBj8DaggSe/
+mRuHUi+IZgPtF09nasr9ZxNVs9S00pxPHjBWwFQ3p+6wY/qQZEQIE0j3iJ9Ly3IL
+RSHZiC0YlrdivcqvvTNc3SO+TW2LWWLbUMSs+IuMVPQpsPvUJ6XN5DuoJHByBbMB
+qgRIRXocTSssKfyRPuPtZHWnlvCgv2fzPmPJqa+z8hnSEdpBTSFCHHgoyRsaTGhg
+VscwWbqvj3YlQhVt62SMTQu82pKdD9I1mS75BHH7Ehb/PHCv7jCSaVc3ztPUquZ6
+wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+      <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
+        <ds:X509Data>
+          <ds:X509Certificate>
+MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
+BQUAMBkxFzAVBgNVBAMTDnZoby5hYWYuZWR1LmF1MB4XDTA5MDUwNDA2MTgyNVoX
+DTI5MDUwNDA2MTgyNVowGTEXMBUGA1UEAxMOdmhvLmFhZi5lZHUuYXUwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDWB4cjn/vxigCmLp1J4Y9OW84acUnO
+YFcb3piAy3fc+dhA6AVHCjLrh7tWRIycmcz5qqIbOFnS5qBqg/zBAAhpPGRHjJTd
+9J6iUN6bWXeaTTBAO9QDtYPt8iAymPFCgbr4lil5JuE9cg6uVgb2/RQlZqludxV6
+aUTbtJePJz5KAVMrlfHVguKjH5GpwVcBztMmtRgOPC37Ptyz9Wo/FxpkwpkZCmag
+tQUTBdSL1lr7ySW4CqH4QCgyplBJ2jOnG2IsGZ0TnCQ5cfNuB9Iw8uU5bBMiZvI+
+2xuDQV4KWyz3lbTHLPHk/Iw57/NdwOeKMLmmJRiRwuJJaOS4MNaPoWsbAgMBAAGj
+YzBhMEAGA1UdEQQ5MDeCDnZoby5hYWYuZWR1LmF1hiVodHRwczovL3Zoby5hYWYu
+ZWR1LmF1L2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBTRu0lIvmQAgPzWEMhtz7Gm
+eYWEqDANBgkqhkiG9w0BAQUFAAOCAQEAUwiq3jCuhENSyehA2AjhmfBj8DaggSe/
+mRuHUi+IZgPtF09nasr9ZxNVs9S00pxPHjBWwFQ3p+6wY/qQZEQIE0j3iJ9Ly3IL
+RSHZiC0YlrdivcqvvTNc3SO+TW2LWWLbUMSs+IuMVPQpsPvUJ6XN5DuoJHByBbMB
+qgRIRXocTSssKfyRPuPtZHWnlvCgv2fzPmPJqa+z8hnSEdpBTSFCHHgoyRsaTGhg
+VscwWbqvj3YlQhVt62SMTQu82pKdD9I1mS75BHH7Ehb/PHCv7jCSaVc3ztPUquZ6
+wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </shibmd:KeyAuthority>
+  </Extensions>
+  <EntityDescriptor entityID='https://test.example.com/myuniqueID1'>
+    <IDPSSODescriptor protocolSupportEnumeration='uri'>
+      <Extensions>
+        <shibmd:Scope regexp='false'>scope</shibmd:Scope>
+        <mdui:UIInfo>
+            <mdui:DisplayName xml:lang="en">Test IdP Name</mdui:DisplayName>
+            <mdui:Description xml:lang="en">Test IdP Description</mdui:Description>
+        </mdui:UIInfo>
+      </Extensions>
+    </IDPSSODescriptor>
+    <SPSSODescriptor protocolSupportEnumeration='uri'>
+      <Extensions>
+        <mdui:UIInfo>
+            <mdui:DisplayName xml:lang="en">Test SP Name</mdui:DisplayName>
+            <mdui:Description xml:lang="en">Test SP Description</mdui:Description>
+        </mdui:UIInfo>
+      </Extensions>
+    </SPSSODescriptor>
+    <Organization>
+      <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
+      <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>
+      <OrganizationURL xml:lang='en'>http://example.com</OrganizationURL>
+    </Organization>
+  </EntityDescriptor>
+  <EntityDescriptor entityID='https://test.example.com/myuniqueID2'>
+    <IDPSSODescriptor protocolSupportEnumeration='uri'>
+      <Extensions>
+        <shibmd:Scope regexp='false'>scope</shibmd:Scope>
+        <mdui:UIInfo>
+            <mdui:DisplayName xml:lang="en">Test IdP Name</mdui:DisplayName>
+            <mdui:Description xml:lang="en">Test IdP Description</mdui:Description>
+        </mdui:UIInfo>
+      </Extensions>
+    </IDPSSODescriptor>
+    <SPSSODescriptor protocolSupportEnumeration='uri'>
+      <Extensions>
+        <mdui:UIInfo>
+            <mdui:DisplayName xml:lang="en">Test SP Name</mdui:DisplayName>
+            <mdui:Description xml:lang="en">Test SP Description</mdui:Description>
+        </mdui:UIInfo>
+      </Extensions>
+    </SPSSODescriptor>
+    <Organization>
+      <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
+      <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>
+      <OrganizationURL xml:lang='en'>http://example.com</OrganizationURL>
+    </Organization>
+  </EntityDescriptor>
+</EntitiesDescriptor>

--- a/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
+++ b/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
@@ -415,6 +415,74 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 		metadataGenerationService.afterPropertiesSet()
 	}
 	
+	def "Test valid EntitiesDescriptor generation with MDUI information"() {
+		setup:
+		setupBindings()
+
+		def savMDUIDisplayName = grailsApplication.config.aaf.fr.metadata.mdui.displayName
+		def savMDUIDescription = grailsApplication.config.aaf.fr.metadata.mdui.description
+		def savMDUILang = grailsApplication.config.aaf.fr.metadata.mdui.lang
+
+		grailsApplication.config.aaf.fr.metadata.mdui.displayName = true
+		grailsApplication.config.aaf.fr.metadata.mdui.description = true
+		grailsApplication.config.aaf.fr.metadata.mdui.lang = 'en'
+		// force the MetatadataGenerationService to re-initialize
+		metadataGenerationService.afterPropertiesSet()
+
+		def organization = Organization.build(active:true, approved:true, name:"Test Organization", displayName:"Test Organization Display", lang:"en", url: "http://example.com")
+		def email = "test@example.com"
+		def home = "(07) 1111 1111"
+		def work = "(567) 222 22222"
+		def mobile = "0413 867 208"
+		def contact = Contact.build(givenName:"Test", surname:"User", email:email, homePhone:home, workPhone:work, mobilePhone:mobile)
+		def admin = ContactType.build(name:"administrative")
+		def contactPerson = ContactPerson.build(contact:contact, type:admin)
+		def dateCreated = new GregorianCalendar(2010, Calendar.JANUARY, 1)
+		dateCreated.setTimeZone(TimeZone.getTimeZone("UTC"))
+
+		def entitiesDescriptor = new EntitiesDescriptor(name:"some.test.name")
+		(1..2).each { i ->
+			def entityDescriptor = EntityDescriptor.build(organization:organization, entityID:"https://test.example.com/myuniqueID$i", active:true, approved:true)
+			// this was ignored in the build method, so a separate assignment
+			entityDescriptor.dateCreated = dateCreated.getTime()
+
+			entityDescriptor.addToContacts(contactPerson)
+
+			entityDescriptor.addToIdpDescriptors(IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, displayName: 'Test IdP Name', description: 'Test IdP Description', active:true, approved:true))
+			entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, displayName: 'Test SP Name', description: 'Test SP Description', active:true, approved:true))
+
+			entitiesDescriptor.addToEntityDescriptors(entityDescriptor)
+      entityDescriptor.validate()
+		}
+
+		def keyInfo = new CAKeyInfo(certificate:new CACertificate(data:loadPK()))
+		def keyInfo2 = new CAKeyInfo(certificate:new CACertificate(data:loadPK2()))
+		def certificateAuthorities = []
+		certificateAuthorities.add(keyInfo)
+		certificateAuthorities.add(keyInfo2)
+
+		def validUntil = new GregorianCalendar(2009, Calendar.JULY, 22)
+		validUntil.setTimeZone(TimeZone.getTimeZone("UTC"))
+
+		def expected = loadExpected('testvalidentitiesdescriptorwmdui')
+
+		when:
+		metadataGenerationService.entitiesDescriptor(builder, false, false, true, entitiesDescriptor, validUntil.getTime(), certificateAuthorities)
+		def xml = writer.toString()
+		def diff = new Diff(expected, xml)
+		def ddiff = new DetailedDiff(diff)
+
+		then:
+		similarExcludingID(ddiff)
+
+		cleanup:
+		grailsApplication.config.aaf.fr.metadata.mdui.displayName = savMDUIDisplayName
+		grailsApplication.config.aaf.fr.metadata.mdui.description = savMDUIDescription
+		grailsApplication.config.aaf.fr.metadata.mdui.lang = savMDUILang
+		// force the MetatadataGenerationService to re-initialize
+		metadataGenerationService.afterPropertiesSet()
+	}
+
 	def "Test valid EntitiesDescriptor generation with embedded entitiesdescriptors and no CA"() {
 		setup:
 		def organization = Organization.build(active:true, approved:true, name:"Test Organization", displayName:"Test Organization Display", lang:"en", url: "http://example.com")


### PR DESCRIPTION
Hi Bradley,

Here's the MDUI support as discussed, complete with config settings (defaulting to off) and spec+tests.

I've tucked along a few fixes - hope you don't mind having them in the same pull-request:
* I had to bump up greenmail from 1.3.2 to 1.3.4 in the plugins, otherwise I would not be able to run tests (and main app was already at 1.3.4)
* I found an omission in the scope regexp code (that was luckily ignored because the code path never reached there), but fixed that for completeness
* I've also added IdP 3.0.x and 3.1.x into the label on the IdP registration form, as the basic registration works the same and the endpoints have not changed either.

Please let me know whether you're happy to merge this or have identified any issues.

Cheers,
Vlad

PS: You can have a look at the live output from my DEV instance at https://registry.dev.tuakiri.ac.nz/federationregistry/metadata/current