### PR TITLE
Replace codehause.org repos with repo.grails.org

### DIFF
--- a/app/federationregistry/grails-app/conf/BuildConfig.groovy
+++ b/app/federationregistry/grails-app/conf/BuildConfig.groovy
@@ -31,8 +31,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }

--- a/app/plugins/administration/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/administration/grails-app/conf/BuildConfig.groovy
@@ -22,8 +22,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }

--- a/app/plugins/api/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/api/grails-app/conf/BuildConfig.groovy
@@ -21,8 +21,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }

--- a/app/plugins/base/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/base/grails-app/conf/BuildConfig.groovy
@@ -19,8 +19,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }

--- a/app/plugins/export/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/export/grails-app/conf/BuildConfig.groovy
@@ -22,8 +22,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }

--- a/app/plugins/metadata/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/metadata/grails-app/conf/BuildConfig.groovy
@@ -21,8 +21,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }

--- a/app/plugins/reporting/grails-app/conf/BuildConfig.groovy
+++ b/app/plugins/reporting/grails-app/conf/BuildConfig.groovy
@@ -21,8 +21,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }


### PR DESCRIPTION
As codehause.org has shut down, their repos no longer work.

Remove all codehaus.org repositories from BuildConfig.groovy files
across the board.

Add instead maven repository http://repo.grails.org/grails/repo/ which
has all the Grails plugins we used to get from codehaus.

Fixes #197