### PR TITLE
Highlight external verification of SAML certs

### DIFF
--- a/app/federationregistry/grails-app/i18n/messages.properties
+++ b/app/federationregistry/grails-app/i18n/messages.properties
@@ -302,6 +302,7 @@ label.requiredattributes=Required Attributes
 label.requiresignedauthn=Requires Signed Authentication Statement
 label.responselocation=Response Location
 label.restrictions=Restrictions
+label.review=Review
 label.revoke=Revoke
 label.roles=Roles
 label.saml=SAML

--- a/app/plugins/base/grails-app/views/templates/certificates/_list.gsp
+++ b/app/plugins/base/grails-app/views/templates/certificates/_list.gsp
@@ -1,6 +1,6 @@
 <div id="certificates">
   <g:if test="${descriptor.keyDescriptors && descriptor.keyDescriptors.findAll{it.disabled == false}.size() > 0}">
-    <g:each in="${descriptor.keyDescriptors.sort{it.id}}" status="i" var="kd">  
+    <g:each in="${descriptor.keyDescriptors.sort{it.id}}" status="i" var="kd">
       <g:if test="${!kd.disabled}">
         <div class="certificate">
           <table class="table borderless">
@@ -51,16 +51,30 @@
                 </td>
               </tr>
               <tr>
+                <th><g:message encodeAs="HTML" code="label.review"/></th>
+                <td>
+          <pre>${kd.keyInfo.certificate.data.trim()}
+
+To review this certificate save it as cert.pem and run:
+
+$> openssl x509 -in cert.pem -noout -text
+</pre>
+                </td>
+              </tr>
+              <tr>
+                <th>Actions</th>
                 <td>
                   <fr:hasPermission target="federation:management:descriptor:${descriptor.id}:crypto:delete">
-                    <a class="confirm-delete-certificate btn btn-mini" data-certificate="${kd.id}"><g:message encodeAs="HTML" code='label.delete'/></a>
+                    <a class="confirm-delete-certificate btn btn-danger" data-certificate="${kd.id}"><g:message encodeAs="HTML" code='label.delete'/></a>
                   </fr:hasPermission>
                 </td>
-                <td/>
               </tr>
             </tbody>
           </table>
         </div>
+        <g:if test="${i + 1 != descriptor.keyDescriptors.size()}">
+          <hr>
+        </g:if>
       </g:if>
     </g:each>
   </g:if>


### PR DESCRIPTION
For use by AAF support in tracking down unexpected issues with IdP/SP
certificate changes.