### PR TITLE
Correct export fault for Contacts without org link

### DIFF
--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
@@ -52,8 +52,10 @@ class Contact {
 	    surname surname
 	    description description ?: ''
 
-	    organization { id this.organization.id
-	    							 name this.organization.displayName }
+	    organization {
+	    	id organization?.id ?: ''
+  			name organization?.displayName ?: ''
+  		}
 
 	    email email
 	    secondary_email secondaryEmail ?: ''


### PR DESCRIPTION
Previously this would result in export not being possible across the
board due to NPE on Contacts that had no Organisation link.

Test with null and non null org values, JSON was as expected.