### PR TITLE
RD exports missing ContactPerson->Contact->id

### DIFF
--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/RoleDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/RoleDescriptor.groovy
@@ -78,6 +78,7 @@ abstract class RoleDescriptor extends Descriptor {
 													 ],
     									  ]
     									}
+      contact_people this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], contact: [id: it.contact.id]] }
       error_url errorURL ?:''
       extensions extensions ?:''
     }


### PR DESCRIPTION
This meant downstream systemts, saml-service specifically, could not
correctly rebuild the environment.