### PR TITLE
Metadata: check IdP/SP/AA descriptors SAML valid

### DIFF
--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/AttributeAuthorityDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/AttributeAuthorityDescriptor.groovy
@@ -40,16 +40,8 @@ class AttributeAuthorityDescriptor extends RoleDescriptor {
 	}
 
 	public boolean samlSchemaValid() {
-		def samlSchemaValid = false
 		// Missing mandatory endpoints indicates an incomplete AttributeAuthorityDescriptor not valid according to the SAML schema
-		if(!samlSchemaValid && attributeServices) {
-		 	attributeServices.each {
-				if(it.functioning())
-					samlSchemaValid = true
-			}
-		}
-
-		samlSchemaValid
+		attributeServices.any { it.functioning() }
 	}
 
 	def structureAsJson() {

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/AttributeAuthorityDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/AttributeAuthorityDescriptor.groovy
@@ -39,6 +39,19 @@ class AttributeAuthorityDescriptor extends RoleDescriptor {
 			( attributeServices?.findAll{it.selfFunctioning()}?.size() > 0 && !archived && active && approved && entityDescriptor.functioning() )
 	}
 
+	public boolean samlSchemaValid() {
+		def samlSchemaValid = false
+		// Missing mandatory endpoints indicates an incomplete AttributeAuthorityDescriptor not valid according to the SAML schema
+		if(!samlSchemaValid && attributeServices) {
+		 	attributeServices.each {
+				if(it.functioning())
+					samlSchemaValid = true
+			}
+		}
+
+		samlSchemaValid
+	}
+
 	def structureAsJson() {
 		def adminRole = Role.findByName("descriptor-${this.id}-administrators")
 

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/EntityDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/EntityDescriptor.groovy
@@ -64,25 +64,25 @@ class EntityDescriptor extends Descriptor  {
 		// No children or no children functioning indicates an empty ED
 		if(empty && idpDescriptors) {
 		 	idpDescriptors.each {
-				if(it.functioning())
+				if(it.functioning() && it.samlSchemaValid())
 					empty = false
 			}
 		}
 		if(empty && attributeAuthorityDescriptors) {
 		 	attributeAuthorityDescriptors.each {
-				if(it.functioning())
+				if(it.functioning() && it.samlSchemaValid())
 					empty = false
 			}
 		}
 		if(empty && spDescriptors) {
 		 	spDescriptors.each {
-				if(it.functioning())
+				if(it.functioning() && it.samlSchemaValid())
 					empty = false
 			}
 		}
 		if(empty && pdpDescriptors) {
 		 	pdpDescriptors.each {
-				if(it.functioning())
+				if(it.functioning() && it.samlSchemaValid())
 					empty = false
 			}
 		}

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/IDPSSODescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/IDPSSODescriptor.groovy
@@ -48,16 +48,9 @@ class IDPSSODescriptor extends SSODescriptor  {
 	}
 
 	public boolean samlSchemaValid() {
-		def samlSchemaValid = false
 		// Missing mandatory endpoints indicates an incomplete IDPSSODescriptor not valid according to the SAML schema
-		if(!samlSchemaValid && singleSignOnServices) {
-		 	singleSignOnServices.each {
-				if(it.functioning())
-					samlSchemaValid = true
-			}
-		}
+		singleSignOnServices.any { it.functioning() }
 
-		samlSchemaValid
 	}
 
 	public List sortedAttributes() {

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/IDPSSODescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/IDPSSODescriptor.groovy
@@ -47,6 +47,19 @@ class IDPSSODescriptor extends SSODescriptor  {
 		( !archived && active && approved && entityDescriptor.functioning() )
 	}
 
+	public boolean samlSchemaValid() {
+		def samlSchemaValid = false
+		// Missing mandatory endpoints indicates an incomplete IDPSSODescriptor not valid according to the SAML schema
+		if(!samlSchemaValid && singleSignOnServices) {
+		 	singleSignOnServices.each {
+				if(it.functioning())
+					samlSchemaValid = true
+			}
+		}
+
+		samlSchemaValid
+	}
+
 	public List sortedAttributes() {
 		def c = Attribute.createCriteria()
 		def attributeList = c.list {

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/PDPDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/PDPDescriptor.groovy
@@ -24,4 +24,17 @@ class PDPDescriptor extends RoleDescriptor {
 	public boolean functioning() {
 		( !archived && active && approved && entityDescriptor.functioning() )
 	}
+
+	public boolean samlSchemaValid() {
+		def samlSchemaValid = false
+		// Missing mandatory endpoints indicates an incomplete PDPDescriptor not valid according to the SAML schema
+		if(!samlSchemaValid && authzServices) {
+		 	authzServices.each {
+				if(it.functioning())
+					samlSchemaValid = true
+			}
+		}
+
+		samlSchemaValid
+	}
 }

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/PDPDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/PDPDescriptor.groovy
@@ -26,15 +26,7 @@ class PDPDescriptor extends RoleDescriptor {
 	}
 
 	public boolean samlSchemaValid() {
-		def samlSchemaValid = false
 		// Missing mandatory endpoints indicates an incomplete PDPDescriptor not valid according to the SAML schema
-		if(!samlSchemaValid && authzServices) {
-		 	authzServices.each {
-				if(it.functioning())
-					samlSchemaValid = true
-			}
-		}
-
-		samlSchemaValid
+		authzServices.any { it.functioning() }
 	}
 }

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/SPSSODescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/SPSSODescriptor.groovy
@@ -38,16 +38,8 @@ class SPSSODescriptor extends SSODescriptor {
 	}
 
 	public boolean samlSchemaValid() {
-		def samlSchemaValid = false
 		// Missing mandatory endpoints indicates an incomplete SPSSODescriptor not valid according to the SAML schema
-		if(!samlSchemaValid && assertionConsumerServices) {
-		 	assertionConsumerServices.each {
-				if(it.functioning())
-					samlSchemaValid = true
-			}
-		}
-
-		samlSchemaValid
+		assertionConsumerServices.any { it.functioning() }
 	}
 
 	public boolean equals(Object obj) {

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/SPSSODescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/SPSSODescriptor.groovy
@@ -37,6 +37,19 @@ class SPSSODescriptor extends SSODescriptor {
 		( !archived && active && approved && entityDescriptor.functioning() )
 	}
 
+	public boolean samlSchemaValid() {
+		def samlSchemaValid = false
+		// Missing mandatory endpoints indicates an incomplete SPSSODescriptor not valid according to the SAML schema
+		if(!samlSchemaValid && assertionConsumerServices) {
+		 	assertionConsumerServices.each {
+				if(it.functioning())
+					samlSchemaValid = true
+			}
+		}
+
+		samlSchemaValid
+	}
+
 	public boolean equals(Object obj) {
 		if( this.is(obj) ) return true
 		if ( obj == null ) return false

--- a/app/plugins/base/test/integration/aaf/fr/foundation/EntityDescriptorSpec.groovy
+++ b/app/plugins/base/test/integration/aaf/fr/foundation/EntityDescriptorSpec.groovy
@@ -49,58 +49,104 @@ class EntityDescriptorSpec extends IntegrationSpec {
 		!ed.functioning()
 	}
 	
-	def "Ensure EntityDescriptor not empty with IDP child"() {
+	def "Ensure EntityDescriptor not empty with a samlValid IDP child"() {
 		when:
-        def o = Organization.build(active:true, approved:true)
+		def o = Organization.build(active:true, approved:true)
+		def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
+		def idp = new IDPSSODescriptor(active:true, approved:true, entityDescriptor:ed)
+		def httpPost = new SamlURI(type:SamlURIType.ProtocolBinding, uri:'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST', description:'')
+		def sso = new SingleSignOnService(descriptor:idp,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+		idp.addToSingleSignOnServices(sso)
+		ed.addToIdpDescriptors(idp)
+
+		then:
+		!ed.empty()
+	}
+
+	def "Ensure EntityDescriptor empty with an IDP child not samlValid"() {
+		when:
+		def o = Organization.build(active:true, approved:true)
 		def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
 		def idp = new IDPSSODescriptor(active:true, approved:true, entityDescriptor:ed)
 		ed.addToIdpDescriptors(idp)
-		
+
+		then:
+		ed.empty()
+	}
+
+	def "Ensure EntityDescriptor not empty with a samlValid SP child"() {
+		when:
+		def o = Organization.build(active:true, approved:true)
+		def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
+		def sp = new SPSSODescriptor(active:true, approved:true, entityDescriptor:ed)
+		def httpArtifact = new SamlURI(type:SamlURIType.ProtocolBinding, uri:'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact', description:'')
+		def acs = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+		sp.addToAssertionConsumerServices(acs)
+		ed.addToSpDescriptors(sp)
+
 		then:
 		!ed.empty()
 	}
-	
-	def "Ensure EntityDescriptor not empty with SP child"() {
-		when:	
-        def o = Organization.build(active:true, approved:true)
-        def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
+
+	def "Ensure EntityDescriptor empty with an SP child not samlValid"() {
+		when:
+		def o = Organization.build(active:true, approved:true)
+		def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
 		def sp = new SPSSODescriptor(active:true, approved:true, entityDescriptor:ed)
 		ed.addToSpDescriptors(sp)
-		
-		then:
-		!ed.empty()
-	}
-	
-	def "Ensure EntityDescriptor not empty with AA child"() {
-		when:
-    def o = Organization.build(active:true, approved:true)
-    def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
-		def aa = new AttributeAuthorityDescriptor(active:true, approved:true, entityDescriptor:ed)
-
-    def soap = new SamlURI(type:SamlURIType.ProtocolBinding, uri:'urn:oasis:names:tc:SAML:2.0:bindings:SOAP', description:'')
-    def attrService = new AttributeService(active:true, approved:true, location:'https://idp.example.org:8443/idp/profile/SAML2/SOAP/AttributeQuery', binding:soap)
-    aa.addToAttributeServices(attrService)
-
-    ed.addToAttributeAuthorityDescriptors(aa)
 
 		then:
-		!ed.empty()
+		ed.empty()
 	}
-	
-	def "Ensure EntityDescriptor not empty with IDP and AA child"() {
+
+	def "Ensure EntityDescriptor not empty with a samlValid AA child"() {
 		when:
-        def o = Organization.build(active:true, approved:true)
-        def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
-		def idp = new IDPSSODescriptor(active:true, approved:true, entityDescriptor:ed)
-		ed.addToIdpDescriptors(idp)
-		
+		def o = Organization.build(active:true, approved:true)
+		def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
 		def aa = new AttributeAuthorityDescriptor(active:true, approved:true, entityDescriptor:ed)
+
+		def soap = new SamlURI(type:SamlURIType.ProtocolBinding, uri:'urn:oasis:names:tc:SAML:2.0:bindings:SOAP', description:'')
+		def attrService = new AttributeService(active:true, approved:true, location:'https://idp.example.org:8443/idp/profile/SAML2/SOAP/AttributeQuery', binding:soap)
+		aa.addToAttributeServices(attrService)
+
 		ed.addToAttributeAuthorityDescriptors(aa)
-		
+
 		then:
 		!ed.empty()
 	}
-	
+
+	def "Ensure EntityDescriptor empty with an AA child not samlValid"() {
+		when:
+		def o = Organization.build(active:true, approved:true)
+		def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
+		def aa = new AttributeAuthorityDescriptor(active:true, approved:true, entityDescriptor:ed)
+
+		ed.addToAttributeAuthorityDescriptors(aa)
+
+		then:
+		ed.empty()
+	}
+
+	def "Ensure EntityDescriptor not empty with samlValid IDP and AA child"() {
+		when:
+		def o = Organization.build(active:true, approved:true)
+		def ed = EntityDescriptor.build(active:true, approved:true, organization:o)
+		def idp = new IDPSSODescriptor(active:true, approved:true, entityDescriptor:ed)
+		def httpPost = new SamlURI(type:SamlURIType.ProtocolBinding, uri:'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST', description:'')
+		def sso = new SingleSignOnService(descriptor:idp,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+		idp.addToSingleSignOnServices(sso)
+		ed.addToIdpDescriptors(idp)
+
+		def aa = new AttributeAuthorityDescriptor(active:true, approved:true, entityDescriptor:ed)
+		def soap = new SamlURI(type:SamlURIType.ProtocolBinding, uri:'urn:oasis:names:tc:SAML:2.0:bindings:SOAP', description:'')
+		def attrService = new AttributeService(active:true, approved:true, location:'https://idp.example.org:8443/idp/profile/SAML2/SOAP/AttributeQuery', binding:soap)
+		aa.addToAttributeServices(attrService)
+		ed.addToAttributeAuthorityDescriptors(aa)
+
+		then:
+		!ed.empty()
+	}
+
 	def "Ensure EntityDescriptor empty when no child nodes"() {
 		when:
 		def ed = new EntityDescriptor()

--- a/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
+++ b/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
@@ -215,9 +215,9 @@ class MetadataGenerationService implements InitializingBean {
               }
             }
           }
-          entityDescriptor.idpDescriptors?.sort{it.id}?.each { idp -> idpSSODescriptor(builder, all, minimal, roleExtensions, idp) }
-          entityDescriptor.spDescriptors?.sort{it.id}?.each { sp -> spSSODescriptor(builder, all, minimal, roleExtensions, sp) }
-          entityDescriptor.attributeAuthorityDescriptors?.sort{it.id}?.each { aa -> attributeAuthorityDescriptor(builder, all, minimal, roleExtensions, aa)}
+          entityDescriptor.idpDescriptors?.findAll{ it.samlSchemaValid() }?.sort{it.id}?.each { idp -> idpSSODescriptor(builder, all, minimal, roleExtensions, idp) }
+          entityDescriptor.spDescriptors?.findAll{ it.samlSchemaValid() }?.sort{it.id}?.each { sp -> spSSODescriptor(builder, all, minimal, roleExtensions, sp) }
+          entityDescriptor.attributeAuthorityDescriptors?.findAll{ it.samlSchemaValid() }?.sort{it.id}?.each { aa -> attributeAuthorityDescriptor(builder, all, minimal, roleExtensions, aa)}
 
           organization(builder, entityDescriptor.organization)
         }

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptor.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptor.xml
@@ -54,8 +54,11 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
       <Extensions>
         <shibmd:Scope regexp='false'>scope</shibmd:Scope>
       </Extensions>
+      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
     </IDPSSODescriptor>
-    <SPSSODescriptor protocolSupportEnumeration='uri' />
+    <SPSSODescriptor protocolSupportEnumeration='uri'>
+      <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+    </SPSSODescriptor>
     <Organization>
       <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
       <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>
@@ -67,8 +70,11 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
       <Extensions>
         <shibmd:Scope regexp='false'>scope</shibmd:Scope>
       </Extensions>
+      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
     </IDPSSODescriptor>
-    <SPSSODescriptor protocolSupportEnumeration='uri' />
+    <SPSSODescriptor protocolSupportEnumeration='uri'>
+      <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+    </SPSSODescriptor>
     <Organization>
       <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
       <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorembedded.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorembedded.xml
@@ -5,8 +5,11 @@
         <Extensions>
           <shibmd:Scope regexp='false'>scope</shibmd:Scope>
         </Extensions>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
       </IDPSSODescriptor>
-      <SPSSODescriptor protocolSupportEnumeration='uri' />
+      <SPSSODescriptor protocolSupportEnumeration='uri'>
+        <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+      </SPSSODescriptor>
       <Organization>
         <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
         <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>
@@ -18,8 +21,11 @@
         <Extensions>
           <shibmd:Scope regexp='false'>scope</shibmd:Scope>
         </Extensions>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
       </IDPSSODescriptor>
-      <SPSSODescriptor protocolSupportEnumeration='uri' />
+      <SPSSODescriptor protocolSupportEnumeration='uri'>
+        <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+      </SPSSODescriptor>
       <Organization>
         <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
         <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorwmdui.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorwmdui.xml
@@ -58,6 +58,7 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
             <mdui:Description xml:lang="en">Test IdP Description</mdui:Description>
         </mdui:UIInfo>
       </Extensions>
+      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
     </IDPSSODescriptor>
     <SPSSODescriptor protocolSupportEnumeration='uri'>
       <Extensions>
@@ -66,6 +67,7 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
             <mdui:Description xml:lang="en">Test SP Description</mdui:Description>
         </mdui:UIInfo>
       </Extensions>
+      <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
     </SPSSODescriptor>
     <Organization>
       <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
@@ -82,6 +84,7 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
             <mdui:Description xml:lang="en">Test IdP Description</mdui:Description>
         </mdui:UIInfo>
       </Extensions>
+      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
     </IDPSSODescriptor>
     <SPSSODescriptor protocolSupportEnumeration='uri'>
       <Extensions>
@@ -90,6 +93,7 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
             <mdui:Description xml:lang="en">Test SP Description</mdui:Description>
         </mdui:UIInfo>
       </Extensions>
+      <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
     </SPSSODescriptor>
     <Organization>
       <OrganizationName xml:lang='en'>Test Organization</OrganizationName>

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorwreginfo.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitiesdescriptorwreginfo.xml
@@ -59,8 +59,11 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
       <Extensions>
         <shibmd:Scope regexp='false'>scope</shibmd:Scope>
       </Extensions>
+      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
     </IDPSSODescriptor>
-    <SPSSODescriptor protocolSupportEnumeration='uri' />
+    <SPSSODescriptor protocolSupportEnumeration='uri'>
+      <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+    </SPSSODescriptor>
     <Organization>
       <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
       <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>
@@ -77,8 +80,11 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
       <Extensions>
         <shibmd:Scope regexp='false'>scope</shibmd:Scope>
       </Extensions>
+      <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
     </IDPSSODescriptor>
-    <SPSSODescriptor protocolSupportEnumeration='uri' />
+    <SPSSODescriptor protocolSupportEnumeration='uri'>
+      <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+    </SPSSODescriptor>
     <Organization>
       <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
       <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitydescriptorschema.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidentitydescriptorschema.xml
@@ -3,15 +3,23 @@
     <Extensions>
       <shibmd:Scope regexp='false'>scope</shibmd:Scope>
     </Extensions>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
   </IDPSSODescriptor>
   <IDPSSODescriptor protocolSupportEnumeration='uri'>
     <Extensions>
       <shibmd:Scope regexp='false'>scope</shibmd:Scope>
     </Extensions>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test.example.com/sso/POST"/>
   </IDPSSODescriptor>
-  <SPSSODescriptor protocolSupportEnumeration='uri' />
-  <SPSSODescriptor protocolSupportEnumeration='uri' />
-  <SPSSODescriptor protocolSupportEnumeration='uri' />
+  <SPSSODescriptor protocolSupportEnumeration='uri'>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+  </SPSSODescriptor>
+  <SPSSODescriptor protocolSupportEnumeration='uri'>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+  </SPSSODescriptor>
+  <SPSSODescriptor protocolSupportEnumeration='uri'>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://test.example.com/acs/ART" index="300" isDefault="false"/>
+  </SPSSODescriptor>
   <Organization>
     <OrganizationName xml:lang='en'>Test Organization</OrganizationName>
     <OrganizationDisplayName xml:lang='en'>Test Organization Display</OrganizationDisplayName>

--- a/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
+++ b/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
@@ -303,7 +303,7 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 	
 	def "Test valid EntitiesDescriptor generation"() {
 		setup:
-    setupBindings()
+		setupBindings()
 
 		def organization = Organization.build(active:true, approved:true, name:"Test Organization", displayName:"Test Organization Display", lang:"en", url: "http://example.com")
 		def email = "test@example.com"
@@ -319,8 +319,14 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 			def entityDescriptor = EntityDescriptor.build(organization:organization, entityID:"https://test.example.com/myuniqueID$i", active:true, approved:true)
 			entityDescriptor.addToContacts(contactPerson)
 
-			entityDescriptor.addToIdpDescriptors(IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
-			entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
+			def idp = IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+			def sso = new SingleSignOnService(descriptor:idp,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+			idp.addToSingleSignOnServices(sso)
+			entityDescriptor.addToIdpDescriptors(idp)
+			def sp = SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+			def acs = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+			sp.addToAssertionConsumerServices(acs)
+			entityDescriptor.addToSpDescriptors(sp)
 
 			entitiesDescriptor.addToEntityDescriptors(entityDescriptor)
       entityDescriptor.validate()
@@ -380,8 +386,14 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 
 			entityDescriptor.addToContacts(contactPerson)
 
-			entityDescriptor.addToIdpDescriptors(IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
-			entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
+			def idp = IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+			def sso = new SingleSignOnService(descriptor:idp,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+			idp.addToSingleSignOnServices(sso)
+			entityDescriptor.addToIdpDescriptors(idp)
+			def sp = SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+			def acs = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+			sp.addToAssertionConsumerServices(acs)
+			entityDescriptor.addToSpDescriptors(sp)
 
 			entitiesDescriptor.addToEntityDescriptors(entityDescriptor)
       entityDescriptor.validate()
@@ -448,8 +460,14 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 
 			entityDescriptor.addToContacts(contactPerson)
 
-			entityDescriptor.addToIdpDescriptors(IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, displayName: 'Test IdP Name', description: 'Test IdP Description', active:true, approved:true))
-			entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, displayName: 'Test SP Name', description: 'Test SP Description', active:true, approved:true))
+			def idp = IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, displayName: 'Test IdP Name', description: 'Test IdP Description', active:true, approved:true)
+			def sso = new SingleSignOnService(descriptor:idp,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+			idp.addToSingleSignOnServices(sso)
+			entityDescriptor.addToIdpDescriptors(idp)
+			def sp = SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, displayName: 'Test SP Name', description: 'Test SP Description', active:true, approved:true)
+			def acs = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+			sp.addToAssertionConsumerServices(acs)
+			entityDescriptor.addToSpDescriptors(sp)
 
 			entitiesDescriptor.addToEntityDescriptors(entityDescriptor)
       entityDescriptor.validate()
@@ -485,6 +503,7 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 
 	def "Test valid EntitiesDescriptor generation with embedded entitiesdescriptors and no CA"() {
 		setup:
+		setupBindings()
 		def organization = Organization.build(active:true, approved:true, name:"Test Organization", displayName:"Test Organization Display", lang:"en", url: "http://example.com")
 		def email = "test@example.com"
 		def home = "(07) 1111 1111"
@@ -500,8 +519,15 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 		(1..2).each { i ->
 			def entityDescriptor = EntityDescriptor.build(organization:organization, entityID:"https://test.example.com/myuniqueID$i", active:true, approved:true)
 			entityDescriptor.addToContacts(contactPerson)
-			entityDescriptor.addToIdpDescriptors(IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
-			entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
+
+			def idp = IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+			def sso = new SingleSignOnService(descriptor:idp,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+			idp.addToSingleSignOnServices(sso)
+			entityDescriptor.addToIdpDescriptors(idp)
+			def sp = SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+			def acs = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+			sp.addToAssertionConsumerServices(acs)
+			entityDescriptor.addToSpDescriptors(sp)
 
 			entitiesDescriptor1.addToEntityDescriptors(entityDescriptor)
 		}
@@ -565,6 +591,7 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 
 	def "Test valid EntityDescriptor generation with schema population"() {
 		setup:
+		setupBindings()
 		def organization = Organization.build(active:true, approved:true, name:"Test Organization", displayName:"Test Organization Display", lang:"en", url: "http://example.com")
 		def email = "test@example.com"
 		def home = "(07) 1111 1111"
@@ -576,11 +603,31 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 		
 		def entityDescriptor = EntityDescriptor.build(organization:organization, entityID:"https://test.example.com/myuniqueID", active:true, approved:true)
 		entityDescriptor.addToContacts(contactPerson)
-		entityDescriptor.addToIdpDescriptors(IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
-		entityDescriptor.addToIdpDescriptors(IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
-		entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
-		entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
-		entityDescriptor.addToSpDescriptors(SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true))
+
+		def idp1 = IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+		def sso1 = new SingleSignOnService(descriptor:idp1,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+		idp1.addToSingleSignOnServices(sso1)
+		entityDescriptor.addToIdpDescriptors(idp1)
+
+		def idp2 = IDPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+		def sso2 = new SingleSignOnService(descriptor:idp2,active:true, approved:true, binding:httpPost, location:"https://test.example.com/sso/POST")
+		idp2.addToSingleSignOnServices(sso2)
+		entityDescriptor.addToIdpDescriptors(idp2)
+
+		def sp1 = SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+		def acs1 = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+		sp1.addToAssertionConsumerServices(acs1)
+		entityDescriptor.addToSpDescriptors(sp1)
+
+		def sp2 = SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+		def acs2 = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+		sp2.addToAssertionConsumerServices(acs2)
+		entityDescriptor.addToSpDescriptors(sp2)
+
+		def sp3 = SPSSODescriptor.build(entityDescriptor:entityDescriptor, organization:organization, active:true, approved:true)
+		def acs3 = new AssertionConsumerService(index:300, active:true, approved:true, binding:httpArtifact, location:"https://test.example.com/acs/ART")
+		sp3.addToAssertionConsumerServices(acs3)
+		entityDescriptor.addToSpDescriptors(sp3)
 
 		def expected = loadExpected('testvalidentitydescriptorschema')
 		


### PR DESCRIPTION
Fix #181 - check that IdP/SP/AA (or PDP) descriptors are SAML valid -
e.g., each has the one mandatory service required by SAML schema
(SingleSignOnService / AssertionConsumerService / AttributeService /
AuthzService).

* Add samlValid() method to each of the descriptors.
* Make MetadataGenerationService filter the descriptors to only render
  those that are samlValid()
* Adjust EntityDescriptor.empty() to only consider descriptors that are
  samlValid()
* Adjust all tests accordingly.  Any metadata generation tests now need
  to define the mandatory service required by the respective descriptor
  - otherwise, the descriptor would not be rendered.