### PR TITLE
Index DateCreated field for WayfAccessRecord

### DIFF
--- a/app/plugins/reporting/grails-app/domain/aaf/fr/reporting/WayfAccessRecord.groovy
+++ b/app/plugins/reporting/grails-app/domain/aaf/fr/reporting/WayfAccessRecord.groovy
@@ -2,7 +2,7 @@ package aaf.fr.reporting
 
 class WayfAccessRecord {
   static auditable = true
-  
+
   String source
   String requestType
   String dsHost
@@ -11,17 +11,21 @@ class WayfAccessRecord {
   // We store these for when things go weird for manual intervention.
   String idpEntity
   String spEndpoint
-  
+
   // We use ID instead of direct links to allow for descriptors to be deleted without impacting reporting
-  long idpID  
+  long idpID
   long spID
-  
+
   boolean robot = false
-  
+
   Date dateCreated
 
   static constraints = {
     dateCreated(nullable: true)
   }
 
+
+  static mapping = {
+    dateCreated index: 'DateCreated_Idx'
+  }
 }


### PR DESCRIPTION
AAF Ops saw incredibly high load on the AAF database cluster and traced it
back to queries originating from FR.

This index should considerably improve the slow query which was
determined to be root cause.