### PR TITLE
AttrList: honour adminRestr on IdP+SP create forms

### DIFF
--- a/app/plugins/base/grails-app/controllers/aaf/fr/foundation/BootstrapController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/foundation/BootstrapController.groovy
@@ -17,6 +17,7 @@ class BootstrapController {
 		def identityProvider = new IDPSSODescriptor()
 		def c = AttributeBase.createCriteria()
 		def attributeList = c.list {
+			eq("adminRestricted", false)
 			order("category", "asc")
 			order("name", "asc")
 		}
@@ -36,6 +37,7 @@ class BootstrapController {
   			flash.message = message(code: 'aaf.fr.foundation.idpssoroledescriptor.register.validation.error')
   			def c = AttributeBase.createCriteria()
   			def attributeList = c.list {
+  				eq("adminRestricted", false)
   				order("category", "asc")
   				order("name", "asc")
   			}
@@ -71,6 +73,7 @@ class BootstrapController {
 		def serviceProvider = new SPSSODescriptor()
 		def c = AttributeBase.createCriteria()
 		def attributeList = c.list {
+			eq("adminRestricted", false)
 			order("category", "asc")
 			order("name", "asc")
 		}
@@ -90,6 +93,7 @@ class BootstrapController {
   			flash.message = message(code: 'aaf.fr.foundation.spssoroledescriptor.register.validation.error')
   			def c = AttributeBase.createCriteria()
   			def attributeList = c.list {
+  				eq("adminRestricted", false)
   				order("category", "asc")
   				order("name", "asc")
   			}

--- a/app/plugins/base/grails-app/controllers/aaf/fr/foundation/IdentityProviderController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/foundation/IdentityProviderController.groovy
@@ -69,6 +69,7 @@ class IdentityProviderController {
         flash.message = message(code: 'aaf.fr.foundation.idpssoroledescriptor.save.validation.error')
         def c = AttributeBase.createCriteria()
         def attributeList = c.list {
+          eq("adminRestricted", false)
           order("category", "asc")
           order("name", "asc")
         }

--- a/app/plugins/base/grails-app/controllers/aaf/fr/foundation/ServiceProviderController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/foundation/ServiceProviderController.groovy
@@ -81,6 +81,7 @@ class ServiceProviderController {
         
         def c = AttributeBase.createCriteria()
         def attributeList = c.list {
+          eq("adminRestricted", false)
           order("category", "asc")
           order("name", "asc")
         }


### PR DESCRIPTION
Honour adminRestricted when populating the attributeList for the IdP / SP create forms.

This has been so far honoured for authenticated create forms (from
IdentityProviderController / ServiceProviderController), but not for the
unauthenticated forms populated from BootstrapControlller.

And it was also not honoured when reloading the form (due to a failed
save) even on the authenticated forms.