### PR TITLE
Fixes to determineProtocolSupport

### DIFF
--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
@@ -76,6 +76,9 @@ class EndpointService {
     log.info "Toggling state of ${endpoint}"
     
     endpoint.active = !endpoint.active
+
+    determineDescriptorProtocolSupport(endpoint.descriptor)
+
     endpoint.save()
     if(endpoint.hasErrors()) {
       endpoint.errors.each {
@@ -118,16 +121,16 @@ class EndpointService {
   }
   
   def determineSPSSODescriptorProtocolSupport(sp) {
-    sp.singleLogoutServices?.each {
+    sp.singleLogoutServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, sp)
     }
-    sp.assertionConsumerServices?.each {
+    sp.assertionConsumerServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, sp)
     }
-    sp.manageNameIDServices?.each {
+    sp.manageNameIDServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, sp)
     }
-    sp.singleLogoutServices?.each {
+    sp.singleLogoutServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, sp)
     }
     
@@ -135,10 +138,10 @@ class EndpointService {
   }
   
   def determineIDPSSODescriptorProtocolSupport(idp) {
-    idp.singleSignOnServices?.each {
+    idp.singleSignOnServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, idp)
     }
-    idp.artifactResolutionServices?.each {
+    idp.artifactResolutionServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, idp)
     }
 
@@ -150,7 +153,7 @@ class EndpointService {
   }
   
   def determineAttributeAuthorityProtocolSupport(def aa) {
-    aa.attributeServices?.each {
+    aa.attributeServices.findAll{ it.functioning() }?.each {
       determineProtocolSupport(it.binding, aa)
     }
     

--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
@@ -130,6 +130,9 @@ class EndpointService {
     sp.singleLogoutServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, sp)
     }
+    sp.artifactResolutionServices?.findAll{ it.functioning() }.each {
+      determineProtocolSupport(it.binding, sp)
+    }
     
     log.debug "Determined current SP protocol support of ${sp.protocolSupportEnumerations}"
   }
@@ -144,6 +147,15 @@ class EndpointService {
     idp.singleLogoutServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, idp)
     }
+    idp.assertionIDRequestServices?.findAll{ it.functioning() }.each {
+      determineProtocolSupport(it.binding, idp)
+    }
+    idp.nameIDMappingServices?.findAll{ it.functioning() }.each {
+      determineProtocolSupport(it.binding, idp)
+    }
+    idp.manageNameIDServices?.findAll{ it.functioning() }.each {
+      determineProtocolSupport(it.binding, idp)
+    }
 
     if(idp.collaborator) {
       determineAttributeAuthorityProtocolSupport(idp.collaborator)
@@ -154,6 +166,9 @@ class EndpointService {
   
   def determineAttributeAuthorityProtocolSupport(def aa) {
     aa.attributeServices.findAll{ it.functioning() }?.each {
+      determineProtocolSupport(it.binding, aa)
+    }
+    aa.assertionIDRequestServices.findAll{ it.functioning() }?.each {
       determineProtocolSupport(it.binding, aa)
     }
     

--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
@@ -121,9 +121,6 @@ class EndpointService {
   }
   
   def determineSPSSODescriptorProtocolSupport(sp) {
-    sp.singleLogoutServices?.findAll{ it.functioning() }.each {
-      determineProtocolSupport(it.binding, sp)
-    }
     sp.assertionConsumerServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, sp)
     }
@@ -142,6 +139,9 @@ class EndpointService {
       determineProtocolSupport(it.binding, idp)
     }
     idp.artifactResolutionServices?.findAll{ it.functioning() }.each {
+      determineProtocolSupport(it.binding, idp)
+    }
+    idp.singleLogoutServices?.findAll{ it.functioning() }.each {
       determineProtocolSupport(it.binding, idp)
     }
 


### PR DESCRIPTION
Hi @bradleybeddoes ,

This is the fix proposed in #233 , plus a few more fixes:
* consider endpoint status for protocolSupport + make toggle a trigger as discussed in #233 
* review endpoints used in the determination and add the missing once:
  * SP had a duplicate iteration over SLO endponts, while IdP was missing them, so move one copy of the duplicate from SP to IdP
  * Add missing endpoints based on additional endpoint types owned by IdP/SP/AA descriptors:
    * SP: ArtifactResolution
    * IdP: NameIDMappingService, ManageNameIDService, AssertionIDRequestService
    * AA: AssertionIDRequestService

Passes Grails tests and works as expected in our DEV environment - please let me know if happy to merge.

Cheers,
Vlad
