### PR TITLE
Metadata: do not emit MDUI for AttributeAuthority

### DIFF
--- a/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
+++ b/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
@@ -435,16 +435,6 @@ class MetadataGenerationService implements InitializingBean {
     boolean isRegex = roleDescriptor.scope.startsWith('^') && roleDescriptor.scope.endsWith('$')
     builder.Extensions() {
       builder."shibmd:Scope" (regexp:isRegex, roleDescriptor.scope)
-      if ( (renderMDUIDisplayName && roleDescriptor.displayName) || (renderMDUIDescription && roleDescriptor.description) ) {
-        builder."mdui:UIInfo" {
-          if (renderMDUIDisplayName && roleDescriptor.displayName) {
-            localizedName(builder, "mdui:DisplayName", mduiLang, roleDescriptor.displayName)
-          }
-          if (renderMDUIDescription && roleDescriptor.description) {
-            localizedName(builder, "mdui:Description", mduiLang, roleDescriptor.description)
-          }
-        }
-      }
     } 
   }
   


### PR DESCRIPTION
Initial MDUI support in 4f8c12e7 was exporting the same IdP MDUI for
both IDPSSODescriptor and AttributeAuthorityDescriptor.

Given an AI is UI-less, there's no point exporting MDUI there.

This gets also flagged by some validators (ukf-metadata) (based on
best-practise assesment).

And it gets removed anyway by the SAML Service.

So removing here...