### PR TITLE
Metadata: drop ds:KeyName from generated metadata

### DIFF
--- a/app/plugins/metadata/grails-app/services/aaf/fr/metadata/AttributeFilterGenerationService.groovy
+++ b/app/plugins/metadata/grails-app/services/aaf/fr/metadata/AttributeFilterGenerationService.groovy
@@ -123,7 +123,9 @@ class AttributeFilterGenerationService {
 	}
 	
 	def comment(builder, comment) {
-		builder.mkp.yieldUnescaped "\n<!-- $comment -->"
+		builder.mkp.yieldUnescaped "\n<!-- "
+		builder.mkp.yield comment.replaceAll("--", "&#x002D;&#x002D;")
+		builder.mkp.yieldUnescaped " -->"
 	}
 
 }

--- a/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
+++ b/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
@@ -105,8 +105,6 @@ class MetadataGenerationService implements InitializingBean {
   
   def caKeyInfo(builder, keyInfo) {
     builder.'ds:KeyInfo'('xmlns:ds':'http://www.w3.org/2000/09/xmldsig#') {
-      if(keyInfo.keyName)
-        'ds:KeyName'(keyInfo.keyName)
       'ds:X509Data'() {
         def data = processCertificateData(keyInfo.certificate.data)
         'ds:X509Certificate'(data)
@@ -116,8 +114,6 @@ class MetadataGenerationService implements InitializingBean {
   
   def keyInfo(builder, keyInfo) {
     builder.'ds:KeyInfo'('xmlns:ds':'http://www.w3.org/2000/09/xmldsig#') {
-      if(keyInfo.keyName)
-        'ds:KeyName'(keyInfo.keyName)
       'ds:X509Data'() {
         def data = processCertificateData(keyInfo.certificate.data)
         'ds:X509Certificate'(data)

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testentitydescriptorwhereidpdoesnotindicateonlyaa.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testentitydescriptorwhereidpdoesnotindicateonlyaa.xml
@@ -5,7 +5,6 @@
     </Extensions>
     <KeyDescriptor use='encryption'>
       <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-        <ds:KeyName>key1</ds:KeyName>
         <ds:X509Data>
           <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -86,7 +85,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
     </Extensions>
     <KeyDescriptor use='encryption'>
       <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-        <ds:KeyName>key1</ds:KeyName>
         <ds:X509Data>
           <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testentitydescriptorwhereidpindicatesonlyaa.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testentitydescriptorwhereidpindicatesonlyaa.xml
@@ -5,7 +5,6 @@
     </Extensions>
     <KeyDescriptor use='encryption'>
       <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-        <ds:KeyName>key1</ds:KeyName>
         <ds:X509Data>
           <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidaadescriptor.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidaadescriptor.xml
@@ -4,7 +4,6 @@
   </Extensions>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -31,7 +30,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalididpssodescriptor.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalididpssodescriptor.xml
@@ -4,7 +4,6 @@
   </Extensions>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalididpssodescriptorwithregexscope.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalididpssodescriptorwithregexscope.xml
@@ -4,7 +4,6 @@
   </Extensions>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptor-nodisc.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptor-nodisc.xml
@@ -1,7 +1,6 @@
 <SPSSODescriptor protocolSupportEnumeration='urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol'>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -28,7 +27,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptor.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptor.xml
@@ -4,7 +4,6 @@
     </Extensions>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -31,7 +30,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornoapprovals.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornoapprovals.xml
@@ -1,7 +1,6 @@
 <SPSSODescriptor protocolSupportEnumeration='urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol'>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -28,7 +27,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornonfuncspecifiedattribute.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornonfuncspecifiedattribute.xml
@@ -4,7 +4,6 @@
     </Extensions>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -31,7 +30,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornora.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornora.xml
@@ -1,7 +1,6 @@
 <SPSSODescriptor protocolSupportEnumeration='urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol'>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -28,7 +27,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornoservicename.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptornoservicename.xml
@@ -1,7 +1,6 @@
 <SPSSODescriptor protocolSupportEnumeration='urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0 urn:oasis:names:tc:SAML:2.0:protocol'>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -28,7 +27,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptorvalidspecifiedattribute.xml
+++ b/app/plugins/metadata/test/data/metadatagenerationservicespec/testvalidspssodescriptorvalidspecifiedattribute.xml
@@ -4,7 +4,6 @@
     </Extensions>
   <KeyDescriptor use='encryption'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key1</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB
@@ -31,7 +30,6 @@ wU7I1/N110XAqdxIAZo7giAij4IKE122u7bPYs8YlQ8JoMb4hPJY5g==
   </KeyDescriptor>
   <KeyDescriptor use='signing'>
     <ds:KeyInfo xmlns:ds='http://www.w3.org/2000/09/xmldsig#'>
-      <ds:KeyName>key2</ds:KeyName>
       <ds:X509Data>
         <ds:X509Certificate>
 MIIDJDCCAgygAwIBAgIVAO0iiNByCKsIji9RIiEglo5mhsc9MA0GCSqGSIb3DQEB

--- a/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
+++ b/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
@@ -1673,7 +1673,7 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
     xml == ""
   }
 
-  def "Test valid AttributeAuthorityDescriptor creation with on AttributeService not functioning"() {
+  def "Test valid AttributeAuthorityDescriptor creation with an AttributeService not functioning"() {
     setup:
     setupBindings()
     def saml2Prot = SamlURI.build(uri:'urn:oasis:names:tc:SAML:2.0:protocol')


### PR DESCRIPTION
The trust model used in the construction of the metadata is based on certificates explicitly included in metadata, not PKI-style trust derived from trusted roots.

Key Name entered in Federation Registry is recorded only as a descriptive name of the key / certificate.

Therefore, emitting the key name as ds:KeyName is superfluous here - and more likely to cause troubles (if relying parties try to interpret it as a name to be verified in a PKI-style chain from a trusted root).

Removing the ds:KeyName (both from shibmd:KeyAuthority and from KeyDescriptor).

Adjusting all tests accordingly (dropping ds:KeyName from expected output)

And fixing a typo in a test name.

And hardining XML comment rendering in AttributeFilterGenerationService.