### PR TITLE
Consider all active endpoints for protocolSupport

### DIFF
--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/EndpointService.groovy
@@ -121,16 +121,16 @@ class EndpointService {
   }
   
   def determineSPSSODescriptorProtocolSupport(sp) {
-    sp.assertionConsumerServices?.findAll{ it.exposed() }.each {
+    sp.assertionConsumerServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, sp)
     }
-    sp.manageNameIDServices?.findAll{ it.exposed() }.each {
+    sp.manageNameIDServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, sp)
     }
-    sp.singleLogoutServices?.findAll{ it.exposed() }.each {
+    sp.singleLogoutServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, sp)
     }
-    sp.artifactResolutionServices?.findAll{ it.exposed() }.each {
+    sp.artifactResolutionServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, sp)
     }
     
@@ -138,22 +138,22 @@ class EndpointService {
   }
   
   def determineIDPSSODescriptorProtocolSupport(idp) {
-    idp.singleSignOnServices?.findAll{ it.exposed() }.each {
+    idp.singleSignOnServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, idp)
     }
-    idp.artifactResolutionServices?.findAll{ it.exposed() }.each {
+    idp.artifactResolutionServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, idp)
     }
-    idp.singleLogoutServices?.findAll{ it.exposed() }.each {
+    idp.singleLogoutServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, idp)
     }
-    idp.assertionIDRequestServices?.findAll{ it.exposed() }.each {
+    idp.assertionIDRequestServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, idp)
     }
-    idp.nameIDMappingServices?.findAll{ it.exposed() }.each {
+    idp.nameIDMappingServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, idp)
     }
-    idp.manageNameIDServices?.findAll{ it.exposed() }.each {
+    idp.manageNameIDServices?.findAll{ it.active }.each {
       determineProtocolSupport(it.binding, idp)
     }
 
@@ -165,10 +165,10 @@ class EndpointService {
   }
   
   def determineAttributeAuthorityProtocolSupport(def aa) {
-    aa.attributeServices.findAll{ it.exposed() }?.each {
+    aa.attributeServices.findAll{ it.active }?.each {
       determineProtocolSupport(it.binding, aa)
     }
-    aa.assertionIDRequestServices.findAll{ it.exposed() }?.each {
+    aa.assertionIDRequestServices.findAll{ it.active }?.each {
       determineProtocolSupport(it.binding, aa)
     }
     


### PR DESCRIPTION
Previously we didn't consider non approved endpoints which is only ever
the case when an IdP/SP etc are first registered. What this meant
however is that IdP/SP that had endpoints added prior to their
registration being approved, e.g. support fixed something up, ended up
with no protocolSupportEnumeration value at all as all endpoints where
discounted.

With this addition changes in endpoints prior to IdP/SP registration
approval will result in a properly calculated protocolSupportEnumeration
value.