### PR TITLE
Allow contacts to be marked as inactive.

### DIFF
--- a/app/plugins/base/grails-app/controllers/aaf/fr/foundation/ContactsController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/foundation/ContactsController.groovy
@@ -12,7 +12,7 @@ class ContactsController {
 	def allowedMethods = [save: 'POST', update: 'PUT']
 	
 	def list = {
-		[contactList: Contact.list(params), contactTotal: Contact.count()]
+		[contactList: Contact.findAllWhere(active: true), contactTotal: Contact.count()]
 	}
 
 	def show = {
@@ -136,6 +136,7 @@ class ContactsController {
 			contact.surname = params.surname
 			contact.email = params.email
 			contact.description = params.description
+      contact.active = params.active
 			
 			if(params.organization) {
 				if(params.organization == "null") {

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
@@ -16,6 +16,8 @@ class Contact {
 	String homePhone
 	String mobilePhone
 
+  Boolean active = true
+
 	Date dateCreated
 	Date lastUpdated
 
@@ -35,6 +37,7 @@ class Contact {
 		mobilePhone(nullable:true)
 		dateCreated(nullable:true)
 		lastUpdated(nullable:true)
+    active(nullable: false)
 	}
 
 	static mapping = {

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/ContactPerson.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/ContactPerson.groovy
@@ -23,6 +23,8 @@ class ContactPerson  {
 		dateCreated(nullable:true)
 		lastUpdated(nullable:true)
 	}
-	
+
+  public Boolean functioning() { this.contact.active }
+
 	public String toString() {	"contactperson:[id:$id, contact: $contact, descriptor:$descriptor, entity:$entity]" }
 }

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/RoleDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/RoleDescriptor.groovy
@@ -78,7 +78,7 @@ abstract class RoleDescriptor extends Descriptor {
 													 ],
     									  ]
     									}
-      contact_people this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], contact: [id: it.contact.id]] }
+      contact_people this.contacts.findAll{it.functioning()}.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], contact: [id: it.contact.id]] }
       error_url errorURL ?:''
       extensions extensions ?:''
     }

--- a/app/plugins/base/grails-app/views/contacts/edit.gsp
+++ b/app/plugins/base/grails-app/views/contacts/edit.gsp
@@ -53,6 +53,18 @@
               <input type="text" name="mobilePhone" value="${fieldValue(bean: contact, field: 'mobilePhone')}" />
             </div>
           </div>
+
+
+          <div class="control-group">
+            <label class="control-label" for="status"><g:message encodeAs="HTML" code="label.status" /></label>
+            <div class="controls">
+              <input type="radio" name="active" value="true"  ${contact.active ? 'checked' : ''}/>
+              <g:message encodeAs="HTML" code="label.active"/>
+            
+              <input type="radio" name="active" alue="false" ${contact.active ? '' : 'checked'}/>
+              <g:message encodeAs="HTML" code="label.inactive"/>
+            </div>
+          </div>
         </fieldset>
 
         <div class="form-actions">

--- a/app/plugins/base/grails-app/views/templates/contacts/_list.gsp
+++ b/app/plugins/base/grails-app/views/templates/contacts/_list.gsp
@@ -10,7 +10,7 @@
         </tr>
       </thead>
       <tbody>
-        <g:each in="${host.contacts?.sort{it.contact.surname}}" var="contactPerson" status="i">
+        <g:each in="${host.contacts?.findAll{it.functioning()}.sort{it.contact.surname}}" var="contactPerson" status="i">
           <tr>
             <td>${fieldValue(bean: contactPerson, field: "contact.givenName")} ${fieldValue(bean: contactPerson, field: "contact.surname")}</td>
             <td><a href="mailto:${contactPerson.contact.email.encodeAsHTML()}">${fieldValue(bean: contactPerson, field: "contact.email")} </a></td>

--- a/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
+++ b/app/plugins/metadata/grails-app/services/aaf/fr/metadata/MetadataGenerationService.groovy
@@ -71,22 +71,24 @@ class MetadataGenerationService implements InitializingBean {
   }
   
   def contactPerson(builder, contactPerson) {
-    // Ignores non SAML standard contact types and contacts marked as 'other'
-    def contactType
-    if(["technical", "support", "administrative", "billing"].contains(contactPerson.type.name)) {
-      
-      builder.ContactPerson(contactType:contactPerson.type.name) {
-        if(contactPerson.contact.organization)
-          Company(contactPerson.contact.organization.displayName)
-        GivenName(contactPerson.contact.givenName)
-        SurName(contactPerson.contact.surname)
-        EmailAddress("mailto:${contactPerson.contact.email}")
-        if(contactPerson.contact.workPhone)
-          TelephoneNumber(contactPerson.contact.workPhone)
-        if(contactPerson.contact.homePhone)
-          TelephoneNumber(contactPerson.contact.homePhone)
-        if(contactPerson.contact.mobilePhone)
-          TelephoneNumber(contactPerson.contact.mobilePhone)
+    if(contactPerson.functioning()) {
+      // Ignores non SAML standard contact types and contacts marked as 'other'
+      def contactType
+      if(["technical", "support", "administrative", "billing"].contains(contactPerson.type.name)) {
+        
+        builder.ContactPerson(contactType:contactPerson.type.name) {
+          if(contactPerson.contact.organization)
+            Company(contactPerson.contact.organization.displayName)
+          GivenName(contactPerson.contact.givenName)
+          SurName(contactPerson.contact.surname)
+          EmailAddress("mailto:${contactPerson.contact.email}")
+          if(contactPerson.contact.workPhone)
+            TelephoneNumber(contactPerson.contact.workPhone)
+          if(contactPerson.contact.homePhone)
+            TelephoneNumber(contactPerson.contact.homePhone)
+          if(contactPerson.contact.mobilePhone)
+            TelephoneNumber(contactPerson.contact.mobilePhone)
+        }
       }
     }
   }
@@ -309,7 +311,7 @@ class MetadataGenerationService implements InitializingBean {
       "${roleExtClassName}Extensions"(builder, all, roleDescriptor)
     roleDescriptor.keyDescriptors?.sort{it.id}.each{keyDescriptor(builder, it)}   
     if(!minimal) {
-      roleDescriptor.contacts?.sort{it.id}.each{cp -> contactPerson(builder, cp)}
+      roleDescriptor.contacts?.findAll{ it.functioning() }?.sort{it.id}.each{cp -> contactPerson(builder, cp)}
     }
   }
   

--- a/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
+++ b/app/plugins/metadata/test/integration/aaf/fr/metadata/MetadataGenerationServiceSpec.groovy
@@ -271,6 +271,24 @@ class MetadataGenerationServiceSpec extends IntegrationSpec {
 		xml == expected
 	}
 
+	def "Test valid contact person generation with non functioning contact"() {
+		setup:
+		def email = "test@example.com"
+		def home = "(07) 1111 1111"
+		def work = "(567) 222 22222"
+		def mobile = "0413 867 208"
+		def contact = Contact.build(givenName:"Test", surname:"User", email:email, homePhone:home, workPhone:work, mobilePhone:mobile, active: false)
+		def ct = ContactType.build(name:"administrative")
+		def contactPerson = ContactPerson.build(contact:contact, type:ct)
+
+		when:
+		metadataGenerationService.contactPerson(builder, contactPerson)
+		
+		then:
+		def xml = writer.toString()
+		xml == ""
+	}
+
   def "Test valid contact person generation with non SAML type"() {
       setup:
       def email = "test@example.com"


### PR DESCRIPTION
Once a contact is no longer active they will not be shown in the user interface.

Additionally any SAML metadata ContactPerson will not be utilised if the linked Contact is inactive.