### PR TITLE
SP3.x: allow separate signing and encryption certs

### DIFF
--- a/app/federationregistry/fr-config.groovy.example
+++ b/app/federationregistry/fr-config.groovy.example
@@ -154,8 +154,8 @@ aaf {
         }
       }
       serviceproviders {
-        shib26 {
-          displayName = "Shibboleth 2.6"
+        shib3 {
+          displayName = "Shibboleth Service Provider (3.x, 2.x)"
           selected = true
           entitydescriptor = '$host/shibboleth'
           acs {

--- a/app/federationregistry/grails-app/i18n/messages.properties
+++ b/app/federationregistry/grails-app/i18n/messages.properties
@@ -581,6 +581,8 @@ help.fr.serviceprovider.attribute.reason=This reasoning will be made publicly av
 help.fr.serviceprovider.attribute.specvalue=A value your service can utilize when transferring the above attribute. Only values explicitly defined will be sent from the users identity provider to your service.  Values starting with ^ and ending with $ will be interpreted as regular expressions in the generated attribute filters.
 
 help.fr.serviceprovider.certificate=Your PEM formatted public key. Must contain the BEGIN/END certificate banners
+help.fr.serviceprovider.certificatesigning=Your PEM formatted signing key. For Shibboleth SP 3 this is `/etc/shibboleth/sp-signing.crt`
+help.fr.serviceprovider.certificateencryption=Your PEM formatted backchannel key. For Shibboleth SP 3 this is `/etc/shibboleth/sp-encrypt.crt`
 help.fr.serviceprovider.connecturl=The URL users will navigate to in order to access this service
 help.fr.serviceprovider.description=This is a publicly available, indepth description of your service. It should clearly outline what the service provides to end users.
 help.fr.serviceprovider.disco=Discovery Service Endpoint

--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/ServiceProviderService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/ServiceProviderService.groovy
@@ -177,21 +177,19 @@ class ServiceProviderService {
 
     // Cryptography
     // Signing
-    if(params.sp?.crypto?.sig) {
-      def cert = cryptoService.createCertificate(params.cert)
-      if(cert) {
-        def keyInfo = new KeyInfo(certificate: cert)
-        def keyDescriptor = new KeyDescriptor(keyInfo:keyInfo, keyType:KeyTypes.signing, encryptionMethod:null)
-        keyDescriptor.roleDescriptor = serviceProvider
-        serviceProvider.addToKeyDescriptors(keyDescriptor)
-      } else {
-        serviceProvider.errors.rejectValue('keyDescriptors', 'aaf.fr.foundation.SPSSODescriptor.crypto.signing.invalid')
-      }
+    def certSIG = cryptoService.createCertificate(params.sigcert)
+    if(certSIG) {
+      def keyInfo = new KeyInfo(certificate: certSIG)
+      def keyDescriptor = new KeyDescriptor(keyInfo:keyInfo, keyType:KeyTypes.signing, encryptionMethod:null)
+      keyDescriptor.roleDescriptor = serviceProvider
+      serviceProvider.addToKeyDescriptors(keyDescriptor)
+    } else {
+      serviceProvider.errors.rejectValue('keyDescriptors', 'aaf.fr.foundation.SPSSODescriptor.crypto.signing.invalid')
     }
 
     // Encryption
-    if(params.sp?.crypto?.enc) {
-      def certEnc = cryptoService.createCertificate(params.cert)
+    if(params.enccert) {
+      def certEnc = cryptoService.createCertificate(params.enccert)
       if(certEnc) {
         def keyInfoEnc = new KeyInfo(certificate:certEnc)
         def keyDescriptorEnc = new KeyDescriptor(keyInfo:keyInfoEnc, keyType:KeyTypes.encryption, encryptionMethod:null)
@@ -199,7 +197,7 @@ class ServiceProviderService {
         serviceProvider.addToKeyDescriptors(keyDescriptorEnc)
       }
       else {
-        identityProvider.errors.rejectValue('keyDescriptors', 'aaf.fr.foundation.IDPSSODescriptor.crypto.encryption.invalid')
+        serviceProvider.errors.rejectValue('keyDescriptors', 'aaf.fr.foundation.SPSSODescriptor.crypto.encryption.invalid')
       }
     }
 
@@ -225,7 +223,8 @@ class ServiceProviderService {
     ret.mnidPost = mnidPost
     ret.discoveryResponseService = discoveryResponseService
     ret.contact = contact
-    ret.certificate = params.cert
+    ret.sigcert = params.sigcert
+    ret.enccert = params.enccert
     ret.supportedAttributes = supportedAttributes
 
     entityDescriptor.addToSpDescriptors(serviceProvider)

--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/ServiceProviderService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/ServiceProviderService.groovy
@@ -202,7 +202,7 @@ class ServiceProviderService {
     }
 
     // Service Description
-    def serviceDescription = new ServiceDescription(connectURL: params.sp?.servicedescription?.connecturl, logo: params.sp?.servicedescription?.logourl, descriptor: serviceProvider)
+    def serviceDescription = new ServiceDescription(connectURL: params.sp?.servicedescription?.connecturl, logoURL: params.sp?.servicedescription?.logourl, descriptor: serviceProvider)
     serviceProvider.serviceDescription = serviceDescription
 
     // Generate return map

--- a/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
+++ b/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
@@ -291,15 +291,22 @@
     <p><g:message encodeAs="HTML" code="templates.fr.serviceprovider.create.crypto.details" /></p>
 
     <fieldset>
+      <div id="newcertificatedetails"></div>
+
       <div class="control-group">
-        <label class="control-label" for="newcertificatedata"><g:message encodeAs="HTML" code="label.certificate" /></label>
+        <label class="control-label"><g:message encodeAs="HTML" code="label.certificatesigning" /></label>
         <div class="controls">
-          <div id="newcertificatedetails">
-          </div>
           <g:hiddenField name="sp.crypto.sig" value="${true}" />
+          <g:textArea name="sigcert" id="sigcert" class="cert required" rows="25" cols="60" value="${sigcert}"/>
+          <fr:tooltip code='help.fr.serviceprovider.certificatesigning' />
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label"><g:message encodeAs="HTML" code="label.certificateencryption" /></label>
+        <div class="controls">
           <g:hiddenField name="sp.crypto.enc" value="${true}" />
-          <g:textArea name="cert" id="cert" class="cert required" rows="25" cols="60" value="${certificate}"/>
-          <fr:tooltip code='help.fr.serviceprovider.certificate' />
+          <g:textArea name="enccert" id="enccert" class="cert required" rows="25" cols="60" value="${enccert}"/>
+          <fr:tooltip code='help.fr.serviceprovider.certificateencryption' />
         </div>
       </div>
     </fieldset>
@@ -405,16 +412,15 @@
       ignore: ":disabled",
       keyup: false
     });
-    jQuery.validator.addMethod("validcert", function(value, element, params) { 
-      fr.validateCertificate();
-      return valid_certificate; 
-    }, jQuery.format("PEM data invalid"));
-    
-    $('#cert').rules("add", {
+
+    $('#sigcert').rules("add", {
          required: true,
-         validcert: true
     });
-    
+
+    $('#enccert').rules("add", {
+         required: false,
+    });
+
     $('#hostname').bind('change',  function() {
       var val = $.trim($(this).val());
       if( val.indexOf('/', val.length - 1) !== -1 && val.length > 9)

--- a/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
+++ b/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
@@ -103,7 +103,7 @@
       <div class="control-group">
         <label class="control-label" for="sp.servicedescription.connecturl"><g:message encodeAs="HTML" code="label.serviceurl" /></label>
         <div class="controls">
-          <g:textField name="sp.servicedescription.connecturl" class="required url span4" value="${servicedescription?.connecturl}"/>
+          <g:textField name="sp.servicedescription.connecturl" class="required url span4" value="${serviceProvider?.serviceDescription?.connectURL}"/>
           <fr:tooltip code='help.fr.serviceprovider.connecturl' />
         </div>
       </div>
@@ -111,7 +111,7 @@
       <div class="control-group">
         <label class="control-label" for="sp.servicedescription.logourl"><g:message encodeAs="HTML" code="label.servicelogourl" /></label>
         <div class="controls">
-          <g:textField name="sp.servicedescription.logourl" class="url span4" value="${servicedescription?.logourl}"/>
+          <g:textField name="sp.servicedescription.logourl" class="url span4" value="${serviceProvider?.serviceDescription?.logoURL}"/>
           <fr:tooltip code='help.fr.serviceprovider.logourl' />
         </div>
       </div>

--- a/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
+++ b/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
@@ -296,7 +296,6 @@
       <div class="control-group">
         <label class="control-label"><g:message encodeAs="HTML" code="label.certificatesigning" /></label>
         <div class="controls">
-          <g:hiddenField name="sp.crypto.sig" value="${true}" />
           <g:textArea name="sigcert" id="sigcert" class="cert required" rows="25" cols="60" value="${sigcert}"/>
           <fr:tooltip code='help.fr.serviceprovider.certificatesigning' />
         </div>
@@ -304,7 +303,6 @@
       <div class="control-group">
         <label class="control-label"><g:message encodeAs="HTML" code="label.certificateencryption" /></label>
         <div class="controls">
-          <g:hiddenField name="sp.crypto.enc" value="${true}" />
           <g:textArea name="enccert" id="enccert" class="cert required" rows="25" cols="60" value="${enccert}"/>
           <fr:tooltip code='help.fr.serviceprovider.certificateencryption' />
         </div>

--- a/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
+++ b/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
@@ -292,7 +292,7 @@
 
     <fieldset>
       <div class="control-group">
-          <label class="control-label" for="newcertificatedata"><g:message encodeAs="HTML" code="label.certificate" /></label>
+        <label class="control-label" for="newcertificatedata"><g:message encodeAs="HTML" code="label.certificate" /></label>
         <div class="controls">
           <div id="newcertificatedetails">
           </div>
@@ -302,6 +302,7 @@
           <fr:tooltip code='help.fr.serviceprovider.certificate' />
         </div>
       </div>
+    </fieldset>
   </div>
 
   <hr>

--- a/app/plugins/base/test/integration/aaf/fr/foundation/ServiceProviderServiceSpec.groovy
+++ b/app/plugins/base/test/integration/aaf/fr/foundation/ServiceProviderServiceSpec.groovy
@@ -67,7 +67,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [identifier:"https://service.test.com"]
-        params.cert = pk
+    params.sigcert = pk
     params.sp = [displayName:"test service name", description:"test desc", attributes:[(attr1.id):[requested: 'on', reasoning:'reason for request', required:'on'], (attr2.id):[requested: 'on', reasoning:'reason for request2', required:'off']], crypto:[sig: true, enc:true],
             acs:[ post:'https://service.test.com/Shibboleth.sso/SAML2/POST', 'post-index':1, artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact', 'artifact-index':2 ], 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', soap:'https://service.test.com/Shibboleth.sso/SLO/SOAP', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect', artifact:'https://service.test.com/Shibboleth.sso/SLO/Artifact'] ] 
@@ -144,7 +144,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [id: ed.id]
-    params.cert = pk
+    params.sigcert = pk
     params.sp = [displayName:"test service name", description:"test desc", attributes:[(attr1.id):[requested: 'on', reasoning:'reason for request', required:'on'], (attr2.id):[requested: 'on', reasoning:'reason for request2', required:'off']], crypto:[sig: true, enc:true],
             acs:[ post:'https://service.test.com/Shibboleth.sso/SAML2/POST', artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact'] , 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', soap:'https://service.test.com/Shibboleth.sso/SLO/SOAP', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect', artifact:'https://service.test.com/Shibboleth.sso/SLO/Artifact'] ] 
@@ -219,7 +219,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [identifier:"https://service2.test.com"]
-        params.cert = pk
+    params.sigcert = pk
     params.sp = [displayName:"test service name", description:"test desc", attributes:[(attr1.id):[requested: 'on', reasoning:'reason for request', required:'on'], (attr2.id):[requested: 'on', reasoning:'reason for request2', required:'off']], crypto:[sig: true, enc:true],
             acs:[ post:'https://service.test.com/Shibboleth.sso/SAML2/POST', artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact'] , 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect' ] ]
@@ -294,7 +294,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [identifier:"https://service.test.com"]
-        params.cert = pk
+    params.sigcert = pk
     params.sp = [displayName:"test service name", description:"test desc", attributes:[(attr1.id):[requested: 'on', reasoning:'reason for request', required:'on'], (attr2.id):[requested: 'on', reasoning:'reason for request2', required:'off']], crypto:[sig: true, enc:true],
             acs:[ artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact'] , 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', soap:'https://service.test.com/Shibboleth.sso/SLO/SOAP', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect', artifact:'https://service.test.com/Shibboleth.sso/SLO/Artifact'] ] 
@@ -366,7 +366,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [identifier:"https://service.test.com"]
-        params.cert = pk
+    params.sigcert = pk
     params.sp = [displayName:"test service name", description:"test desc", attributes:[(attr1.id):[requested: 'on', required:'on'], (attr2.id):[requested: 'on', reasoning:'', required:'off']], crypto:[sig: true, enc:true],
             acs:[ post:'https://service.test.com/Shibboleth.sso/SAML2/POST', artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact'] , 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', soap:'https://service.test.com/Shibboleth.sso/SLO/SOAP', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect', artifact:'https://service.test.com/Shibboleth.sso/SLO/Artifact'] ] 
@@ -438,7 +438,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [identifier:"https://service.test.com"]
-        params.cert = pk
+    params.sigcert = pk
     params.sp = [displayName:"test service name", description:"test desc", attributes:[(attr1.id):[requested: 'on', reasoning:'reason for request', required:'on'], (attr2.id):[requested: 'on', reasoning:'reason for request2', required:'off']], crypto:[sig: true, enc:true],
             acs:[ post:'https://service.test.com/Shibboleth.sso/SAML2/POST', artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact'] , 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', soap:'https://service.test.com/Shibboleth.sso/SLO/SOAP', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect', artifact:'https://service.test.com/Shibboleth.sso/SLO/Artifact'] ] 
@@ -499,7 +499,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [identifier:"https://service.test.com"]
-        params.cert = pk
+    params.sigcert = pk
     params.sp = [displayName:"test service name", description: null, attributes:[(attr1.id):[requested: 'on', reasoning:'reason for request', required:'on'], (attr2.id):[requested: 'on', reasoning:'reason for request2', required:'off']], crypto:[sig: true, enc:true],
             acs:[ post:'https://service.test.com/Shibboleth.sso/SAML2/POST', artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact'] , 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', soap:'https://service.test.com/Shibboleth.sso/SLO/SOAP', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect', artifact:'https://service.test.com/Shibboleth.sso/SLO/Artifact'] ] 
@@ -562,7 +562,7 @@ class ServiceProviderServiceSpec extends IntegrationSpec {
     params.organization = [id: organization.id]
     params.active = true
     params.entity = [identifier:"https://service.test.com"]
-        params.cert = pk
+    params.sigcert = pk
     params.sp = [description:"test desc", attributes:[(attr1.id):[requested: 'on', reasoning:'reason for request', required:'on'], (attr2.id):[requested: 'on', reasoning:'reason for request2', required:'off']], crypto:[sig: true, enc:true],
             acs:[ post:'https://service.test.com/Shibboleth.sso/SAML2/POST', artifact:'https://service.test.com/Shibboleth.sso/SAML2/Artifact'] , 
             slo:[post:'https://service.test.com/Shibboleth.sso/SLO/Post', soap:'https://service.test.com/Shibboleth.sso/SLO/SOAP', redirect:'https://service.test.com/Shibboleth.sso/SLO/Redirect', artifact:'https://service.test.com/Shibboleth.sso/SLO/Artifact'] ] 


### PR DESCRIPTION
Hi @bradleybeddoes ,

With SP3 installer now creating separete signing and encryption certificates, I've adjusted the CreateSP form to support this.

I was mostly following what you did in a2e203c for the IdP.

All tests pass and works for me - would you be happy to merge this?

Cheers,
Vlad

PS: Also made a few fixes along the way... and bumped up the supported SP version listed on the CreateSP form.