### PR TITLE
Fix several issues around Contact.active

### DIFF
--- a/app/plugins/base/grails-app/controllers/aaf/fr/foundation/ContactsController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/foundation/ContactsController.groovy
@@ -12,7 +12,7 @@ class ContactsController {
 	def allowedMethods = [save: 'POST', update: 'PUT']
 	
 	def list = {
-		[contactList: Contact.findAllWhere(active: true), contactTotal: Contact.count()]
+		[contactList: Contact.list(params), contactTotal: Contact.count()]
 	}
 
 	def show = {

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
@@ -16,7 +16,7 @@ class Contact {
 	String homePhone
 	String mobilePhone
 
-  Boolean active = true
+	boolean active = true
 
 	Date dateCreated
 	Date lastUpdated
@@ -43,6 +43,7 @@ class Contact {
 	static mapping = {
 		autoImport false
 		sort "surname"
+		active defaultValue: true
 	}
 
 	public String toString() { "contact:[id:$id, givenName: $givenName, surname: $surname, email: $email]" }

--- a/app/plugins/base/grails-app/views/contacts/list.gsp
+++ b/app/plugins/base/grails-app/views/contacts/list.gsp
@@ -13,6 +13,7 @@
           <th><g:message encodeAs="HTML" code='label.surname' /></th>
           <th><g:message encodeAs="HTML" code='label.email' /></th>
           <th><g:message encodeAs="HTML" code='label.organization' /></th>
+          <th><g:message encodeAs="HTML" code='label.active' /></th>
           <th/>
         </tr>
       </thead>
@@ -23,6 +24,7 @@
           <td>${fieldValue(bean: contact, field: "surname")}</td>
           <td><a href="mailto:${fieldValue(bean: contact, field: "email")}">${fieldValue(bean: contact, field: "email")}</a></td>
           <td>${fieldValue(bean: contact, field: "organization.displayName")}</td>
+          <td>${fieldValue(bean: contact, field: "active")}</td>
           <td><a href="${createLink(action:'show', id:contact.id)}" class="btn"><g:message encodeAs="HTML" code="label.view" default="View"/></a></td>
         </tr>
       </g:each>

--- a/app/plugins/base/grails-app/views/templates/contacts/_list.gsp
+++ b/app/plugins/base/grails-app/views/templates/contacts/_list.gsp
@@ -6,6 +6,7 @@
           <th><g:message encodeAs="HTML" code="label.name" /></th>
           <th><g:message encodeAs="HTML" code="label.email" /></th>
           <th><g:message encodeAs="HTML" code="label.type" /></th>
+          <th><g:message encodeAs="HTML" code="label.active" /></th>
           <th/>
         </tr>
       </thead>
@@ -15,6 +16,7 @@
             <td>${fieldValue(bean: contactPerson, field: "contact.givenName")} ${fieldValue(bean: contactPerson, field: "contact.surname")}</td>
             <td><a href="mailto:${contactPerson.contact.email.encodeAsHTML()}">${fieldValue(bean: contactPerson, field: "contact.email")} </a></td>
             <td>${fieldValue(bean: contactPerson, field: "type.displayName")}</td>
+            <td>${fieldValue(bean: contactPerson, field: "contact.active")}</td>
             <td>
               <a href="${createLink(controller:'contacts', action:'show', id: contactPerson.contact.id)}" class="btn btn-small"><g:message encodeAs="HTML" code='label.view'/></a>
               <fr:hasAnyPermission in='["federation:management:${hostType}:${host.id}:contact:remove", "federation:management:contacts"]'>

--- a/app/plugins/base/grails-app/views/templates/contacts/_list.gsp
+++ b/app/plugins/base/grails-app/views/templates/contacts/_list.gsp
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody>
-        <g:each in="${host.contacts?.findAll{it.functioning()}.sort{it.contact.surname}}" var="contactPerson" status="i">
+        <g:each in="${host.contacts?.sort{it.contact.surname}}" var="contactPerson" status="i">
           <tr>
             <td>${fieldValue(bean: contactPerson, field: "contact.givenName")} ${fieldValue(bean: contactPerson, field: "contact.surname")}</td>
             <td><a href="mailto:${contactPerson.contact.email.encodeAsHTML()}">${fieldValue(bean: contactPerson, field: "contact.email")} </a></td>


### PR DESCRIPTION
Hi @bradleybeddoes ,

As discussed in #248, this PR:
* fixes the defaultValue of Contact.active to be true - so on upgrade, Contact's would not suddenly disappear
* includes inactive contacts on the Federation Contacts list (so that it is possible to re-activate them)
* and adds a column "active" to allow distinguishing active and inactive contacts
* and also includes inactive contacts on the Org/IdP/SP page
  * again with an "active" column
  * this is to allow actually removing the Contact from being associated with the Org/IdP/SP
  * but of course, inactive contacts are not rendered in the IdP/SP metadata
* and inactive contacts are not listed on the Search Results page.

I understand from your note in #248 that it may take a while until this gets reviewed.
I have merged it in our fork and deployed in our internal TEST environment.

I'll post a note here once it's in our public TEST and in PROD.

Cheers,
Vlad
