### PR TITLE
base/Contact.active: set defaultValue to true

### DIFF
--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/Contact.groovy
@@ -16,7 +16,7 @@ class Contact {
 	String homePhone
 	String mobilePhone
 
-  Boolean active = true
+	boolean active = true
 
 	Date dateCreated
 	Date lastUpdated
@@ -43,6 +43,7 @@ class Contact {
 	static mapping = {
 		autoImport false
 		sort "surname"
+		active defaultValue: true
 	}
 
 	public String toString() { "contact:[id:$id, givenName: $givenName, surname: $surname, email: $email]" }


### PR DESCRIPTION
Follow-up to #243 / c63e1d7 - set defaultValue to true (so that all
contacts do not get automatically marked as not active).

Replaces #249 - includes the defaultValue commit only, as requested by @bradleybeddoes 