### PR TITLE
Fix certificate validation on IdP/SP create forms (+misc)

### DIFF
--- a/app/plugins/base/grails-app/controllers/aaf/fr/foundation/DescriptorAdministrationController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/foundation/DescriptorAdministrationController.groovy
@@ -201,7 +201,7 @@ class DescriptorAdministrationController {
     if(SecurityUtils.subject.isPermitted("federation:management:descriptor:${descriptor.id}:manage:administrators")) {
       if(subj == subject) {
         flash.type="error"
-        flash.message = message(code: 'controller.descriptoradministration.selfedit', default:"Admins can't remove their own privileged access.")
+        flash.message = message(code: 'controller.descriptoradministration.selfedit', default:"Administrators cannot remove their own privileged access.")
         redirect(controller: controller, action: "show", id:descriptor.id, fragment:"tab-admins")
         return
       }

--- a/app/plugins/base/grails-app/controllers/aaf/fr/foundation/OrganizationController.groovy
+++ b/app/plugins/base/grails-app/controllers/aaf/fr/foundation/OrganizationController.groovy
@@ -310,7 +310,7 @@ class OrganizationController {
     if(SecurityUtils.subject.isPermitted("federation:management:organization:${organization.id}:administrators")) {
       if(subj == subject) {
         flash.type="error"
-        flash.message = message(code: 'controller.organizationadministration.selfedit', default:"Admins can't remove their own privileged access.")
+        flash.message = message(code: 'controller.organizationadministration.selfedit', default:"Administrators cannot remove their own privileged access.")
         redirect(action: "show", id:organization.id, fragment:"tab-admins")
         return
       }

--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/IdentityProviderService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/IdentityProviderService.groovy
@@ -189,7 +189,7 @@ class IdentityProviderService {
     }
 
     // Check contact explicitly to avoid TransientObjectException
-    if(!entityDescriptor.validate() || contact.hasErrors()) {
+    if(!entityDescriptor.validate() || contact.hasErrors() || identityProvider.hasErrors() ) {
             log.info "$subject attempted to create $identityProvider but failed input validation"
       entityDescriptor.errors.each {log.debug it}
       TransactionAspectSupport.currentTransactionStatus().setRollbackOnly()

--- a/app/plugins/base/grails-app/services/aaf/fr/foundation/ServiceProviderService.groovy
+++ b/app/plugins/base/grails-app/services/aaf/fr/foundation/ServiceProviderService.groovy
@@ -234,7 +234,7 @@ class ServiceProviderService {
     }
 
     // Check contact explicitly to avoid TransientObjectException
-    if(!entityDescriptor.validate() || contact.hasErrors()) {
+    if(!entityDescriptor.validate() || contact.hasErrors() || serviceProvider.hasErrors()) {
       log.info "$subject attempted to create $serviceProvider but failed input validation"
       entityDescriptor.errors.each {log.debug it}
       TransactionAspectSupport.currentTransactionStatus().setRollbackOnly()

--- a/app/plugins/base/grails-app/views/templates/descriptor/_listfulladministration.gsp
+++ b/app/plugins/base/grails-app/views/templates/descriptor/_listfulladministration.gsp
@@ -41,7 +41,7 @@
       <form id="addfulladministrator" method="POST" class="validating" action='${g.createLink(controller:"descriptorAdministration", action:"grantFullAdministrationToken")}'>
         <g:hiddenField name="id" value="${descriptor.id}" />
         <div class="input-prepend">
-          <span class="add-on"><strong>CODE</strong> </span><input class="span2 required" id="token" name="token" size="16" type="text">
+          <span class="add-on"><strong>CODE</strong> </span><input class="span2 required" id="token" name="token" size="16" type="text" autocomplete="off">
         </div>
         <input type="submit" name="submit" value="${message(code: 'label.submitcode', default: 'Submit Code')}" class="btn btn-success btn-large" />
       </form>

--- a/app/plugins/base/grails-app/views/templates/organization/_listfulladministration.gsp
+++ b/app/plugins/base/grails-app/views/templates/organization/_listfulladministration.gsp
@@ -41,7 +41,7 @@
       <g:form controller="organization" action="grantFullAdministrationToken" method="POST">
         <g:hiddenField name="id" value="${organization.id}" />
         <div class="input-prepend">
-          <span class="add-on"><strong>CODE</strong> </span><input class="span2" id="token" name="token" size="16" type="text">
+          <span class="add-on"><strong>CODE</strong> </span><input class="span2 required" id="token" name="token" size="16" type="text" autocomplete="off">
         </div>
         <g:submitButton name="submit" value="${message(code: 'label.submitcode', default: 'Submit Code')}" class="btn btn-success btn-large" />
       </g:form>

--- a/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
+++ b/app/plugins/base/grails-app/views/templates/serviceprovider/_create.gsp
@@ -303,7 +303,7 @@
       <div class="control-group">
         <label class="control-label"><g:message encodeAs="HTML" code="label.certificateencryption" /></label>
         <div class="controls">
-          <g:textArea name="enccert" id="enccert" class="cert required" rows="25" cols="60" value="${enccert}"/>
+          <g:textArea name="enccert" id="enccert" class="cert" rows="25" cols="60" value="${enccert}"/>
           <fr:tooltip code='help.fr.serviceprovider.certificateencryption' />
         </div>
       </div>

--- a/app/plugins/base/test/integration/aaf/fr/foundation/IdentityProviderServiceSpec.groovy
+++ b/app/plugins/base/test/integration/aaf/fr/foundation/IdentityProviderServiceSpec.groovy
@@ -883,7 +883,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     ret.ecp.location == "/idp/profile/SAML2/SOAP/ECP"
   }
 
-  def "Create succeeds when IDPSSODescriptor crypto not supplied"() {
+  def "Create fails when IDPSSODescriptor crypto not supplied"() {
     setup:
     setupBindings()
     setupCrypto()
@@ -908,18 +908,10 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     def wfProcessName, wfDescription, wfPriority, wfParams
 
     when:
-    WorkflowProcessService.metaClass.initiate =  { String processName, String instanceDescription, ProcessPriority priority, Map params ->
-      wfProcessName = processName
-      wfDescription = instanceDescription
-      wfPriority = priority
-      wfParams = params
-      [true, [:]]
-    }
-    WorkflowProcessService.metaClass.run = { def processInstance -> }
     def (created, ret) = IdentityProviderService.create(params)
 
     then:
-    created
+    !created
 
     def identityProvider = ret.identityProvider
     def attributeAuthority = ret.attributeAuthority
@@ -927,7 +919,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     identityProvider.organization == organization
     identityProvider.entityDescriptor == entityDescriptor
     identityProvider.entityDescriptor.organization == organization
-    identityProvider.collaborator == attributeAuthority
+    identityProvider.collaborator == null
 
     identityProvider.displayName == "test name"
     identityProvider.description == "test desc"
@@ -946,14 +938,6 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
 
     identityProvider.artifactResolutionServices.size() == 1
     identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
-
-    wfProcessName == "idpssodescriptor_create"
-
-    wfPriority == ProcessPriority.MEDIUM
-    wfParams.size() == 5
-    wfParams.creator == "${contact.id}"
-    wfParams.identityProvider == "${identityProvider.id}"
-    wfParams.organization == "${organization.id}"
   }
 
   def "Backchannel crypto is correctly registered"() {


### PR DESCRIPTION
Hi @bradleybeddoes ,

I have come across an issue: an SP registration with invalid certs (pasted without the BEGIN/END banners) went through, but the certs were discarded.

When investigating, I found it applies to IdP as well.

I have tracked it down to the changes done for the IdP in #208 - which I reused for SP in #247 .

As part of the changes (to support multiple certificates and drop too tight validation rules), the validation moved from the form into the IdP/SP Service.create method.

There, the validation code reports errors returned by `CryptoService` by adding them to the `errors` list of the IdP/SP object... but that error list is never checked.  I've added an IdP/SP `hasErrors()` call to the final validation check - that fixes it.

I also had to adjust the spec (... "to make tests pass" ... ) - but here, the adjustment is legit: creating an IdP without crypto supplied should fail (the signing cert is required), so I changed the `Create succeeds when IDPSSODescriptor crypto not supplied` to a fail scenario (... and removed the workflow bits as they do not apply to a failed create).

I've also fixed two minor things I came across:
* UI only: do not mark SP encryption cert as required
* UI only: disable autocomplete for invite code fields.

All tests are passing and I'm running this in our DEV/TEST env.
(will post once I promote it to PROD).

Please let me know if happy to merge (or if you see any concerns).

Cheers,
Vlad