### PR TITLE
Remove 8443 defaults

### DIFF
--- a/app/federationregistry/web-app/js/application.js
+++ b/app/federationregistry/web-app/js/application.js
@@ -1267,9 +1267,6 @@ fr.configureIdentityProviderSAML = function(host) {
     $('#idp\\.post').val( knownIDPImpl[currentImpl].post.uri.replace('$host', host) );
     $('#idp\\.redirect').val( knownIDPImpl[currentImpl].redirect.uri.replace('$host', host) );
     $('#idp\\.ecp').val( knownIDPImpl[currentImpl].ecp.uri.replace('$host', host) );
-    $('#idp\\.artifact').val( knownIDPImpl[currentImpl].artifact.uri.replace('$host', host) );
-    $('#idp\\.artifact-index').val( knownIDPImpl[currentImpl].artifact.index );
-    $('#aa\\.attributeservice').val( knownIDPImpl[currentImpl].attributeservice.uri.replace('$host', host) );
   }
 };
 

--- a/app/plugins/base/grails-app/views/templates/identityprovider/_create.gsp
+++ b/app/plugins/base/grails-app/views/templates/identityprovider/_create.gsp
@@ -87,7 +87,6 @@
         <div class="control-group">
           <label class="control-label" for="idp.displayName"><g:message encodeAs="HTML" code="label.displayname" /></label>
           <div class="controls">
-            <g:hiddenField name="aa.displayName" value=""/>
             <g:textField name="idp.displayName" class="required span4" value="${identityProvider?.displayName}"/>
             <fr:tooltip code='help.fr.identityprovider.displayname' />
           </div>
@@ -96,7 +95,6 @@
         <div class="control-group">
           <label class="control-label" for="idp.description"><g:message encodeAs="HTML" code="label.description" /></label>
           <div class="controls">
-            <g:hiddenField name="aa.description" />
             <g:textArea name="idp.description"  class="required span4" rows="8" value="${identityProvider?.description}"/>
             <fr:tooltip code='help.fr.identityprovider.description' />
           </div>
@@ -181,32 +179,6 @@
             </div>
           </div>
         </fieldset>
-        <hr>
-        <fieldset>
-          <div class="control-group">
-            <label class="control-label" for="idp.artifact"><g:message encodeAs="HTML" code="label.soapartifactendpoint" /></label>
-            <div class="controls">
-              <g:textField name="idp.artifact" size="64" class="required url span4" value="${soapArtifact?.location}"/>
-
-              <span class="index">Index:</span>
-              <g:textField name="idp.artifact-index" size="2" class="required number index span1" value="${soapArtifact?.index}"/>
-              <fr:tooltip code='help.fr.identityprovider.authartifact' />
-              <br><span class="binding"><strong><g:message encodeAs="HTML" code="label.binding" /></strong>: SAML:2.0:bindings:HTTP-Artifact</span>
-            </div>
-          </div>
-        </fieldset>
-        <hr>
-        <fieldset>
-          <div class="control-group">
-            <label class="control-label" for="aa.attributeservice"><g:message encodeAs="HTML" code="label.soapatrributequeryendpoint" /></label>
-
-            <div class="controls">
-              <g:textField name="aa.attributeservice" size="64" class="required url span4" value="${soapAttributeService?.location}"/>
-              <fr:tooltip code='help.fr.identityprovider.aasoap' />
-              <br><span class="binding"><strong><g:message encodeAs="HTML" code="label.binding" /></strong>: SAML:2.0:bindings:SOAP</span>
-            </div>
-          </div>
-        </fieldset>
       </div>
     </div>
 
@@ -243,15 +215,6 @@
             <g:hiddenField name="idp.crypto.sig" value="${true}" />
             <g:textArea name="sigcert" id="sigcert" class="cert required" rows="25" cols="60" value="${sigcert}"/>
             <fr:tooltip code='help.fr.identityprovider.certificatesigning' />
-          </div>
-        </div>
-
-        <div class="control-group">
-          <label class="control-label"><g:message encodeAs="HTML" code="label.certificatebackchannel" /></label>
-          <div class="controls">
-            <g:hiddenField name="idp.crypto.bc" value="${true}" />
-            <g:textArea name="bccert" id="bccert" class="cert" rows="25" cols="60" value="${bccert}"/>
-            <fr:tooltip code='help.fr.identityprovider.certificatebackchannel' />
           </div>
         </div>
 

--- a/app/plugins/base/test/integration/aaf/fr/foundation/AttributeConsumingServiceControllerSpec.groovy
+++ b/app/plugins/base/test/integration/aaf/fr/foundation/AttributeConsumingServiceControllerSpec.groovy
@@ -78,6 +78,8 @@ class AttributeConsumingServiceControllerSpec extends IntegrationSpec {
     acs.addToRequestedAttributes(ra1)
     acs.save()
     
+    def wfProcessName, wfDescription, wfPriority, wfParams
+
     controller.params.id = acs.id
     controller.params.attrid = ra1.base.id
     controller.params.reasoning = "I really need it!"

--- a/app/plugins/base/test/integration/aaf/fr/foundation/IdentityProviderServiceSpec.groovy
+++ b/app/plugins/base/test/integration/aaf/fr/foundation/IdentityProviderServiceSpec.groovy
@@ -782,13 +782,6 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     }
 
     identityProvider.artifactResolutionServices == null
-
-    wfProcessName == "idpssodescriptor_create"
-    wfPriority == ProcessPriority.MEDIUM
-    wfParams.size() == 5
-    wfParams.creator == "${contact.id}"
-    wfParams.identityProvider == "${identityProvider.id}"
-    wfParams.organization == "${organization.id}"
   }
 
   def "Encryption crypto is correctly registered"() {

--- a/app/plugins/base/test/integration/aaf/fr/foundation/IdentityProviderServiceSpec.groovy
+++ b/app/plugins/base/test/integration/aaf/fr/foundation/IdentityProviderServiceSpec.groovy
@@ -123,8 +123,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
       sso2.location == "http://identityProvider.test.com/SAML2/POST/SSO"
     }
 
-    identityProvider.artifactResolutionServices.size() == 1
-    identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     identityProvider.attributes != null
     identityProvider.attributes.size() == 2
@@ -143,7 +142,6 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     attributeAuthority.entityDescriptor == entityDescriptor
     attributeAuthority.collaborator == identityProvider
     identityProvider.collaborator == attributeAuthority
-
 
     attributeAuthority.attributes == null   // Metadata renders off IdP attribute set so we can maintain in one place.
 
@@ -220,8 +218,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
       sso2.location == "http://identityProvider.test.com/SAML2/POST/SSO"
     }
 
-    identityProvider.artifactResolutionServices.size() == 1
-    identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     identityProvider.attributes != null
     identityProvider.attributes.size() == 2
@@ -315,8 +312,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
       sso2.location == "http://identityProvider.test.com/SAML2/POST/SSO"
     }
 
-    identityProvider.artifactResolutionServices.size() == 1
-    identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     identityProvider.attributes != null
     identityProvider.attributes.size() == 2
@@ -441,19 +437,14 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     identityProvider.singleSignOnServices.contains(ret.httpRedirect)
     ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     identityProvider.contacts.size() == 1
     identityProvider.contacts.toList().get(0).id == null
 
-
     attributeAuthority.organization == organization
     attributeAuthority.entityDescriptor == entityDescriptor
     attributeAuthority.collaborator == null
-
   }
 
   def "Create fails when IDPSSODescriptor post endpoint fails constraints"() {
@@ -508,16 +499,11 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     identityProvider.singleSignOnServices.contains(ret.httpRedirect)
     ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
-
+    identityProvider.artifactResolutionServices == null
 
     attributeAuthority.organization == organization
     attributeAuthority.entityDescriptor == entityDescriptor
     attributeAuthority.collaborator == null
-
   }
 
   def "Create fails when IDPSSODescriptor post endpoint not supplied"() {
@@ -574,11 +560,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     identityProvider.singleSignOnServices.contains(ret.httpRedirect)
     ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
-
+    identityProvider.artifactResolutionServices == null
 
     attributeAuthority.organization == organization
     attributeAuthority.entityDescriptor == entityDescriptor
@@ -638,10 +620,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     ret.httpRedirect.errors.getErrorCount() == 1
     ret.httpRedirect.errors.getFieldError('location').code == 'url.invalid'
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     attributeAuthority.organization == organization
     attributeAuthority.entityDescriptor == entityDescriptor
@@ -702,141 +681,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     ret.httpRedirect.hasErrors()
     ret.httpRedirect.errors.getFieldError('location').code == 'nullable'
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
-
-    attributeAuthority.organization == organization
-    attributeAuthority.entityDescriptor == entityDescriptor
-    attributeAuthority.collaborator == null
-
-  }
-
-  def "Create fails when IDPSSODescriptor artifact endpoint fails constraints"() {
-    setup:
-    setupBindings()
-    setupCrypto()
-
-    def saml2Prot = SamlURI.build(uri:'urn:oasis:names:tc:SAML:2.0:protocol')
-    def organization = Organization.build()
-    def entityDescriptor = EntityDescriptor.build(organization:organization)
-    def attr1 = Attribute.build()
-    def attr2 = Attribute.build()
-    def pk = loadPK()
-    def contact = Contact.build(organization: organization)
-    def ct = new ContactType(name:'technical', displayName:'Technical', description: 'Technical contacts').save()
-
-    params.organization = [id: organization.id]
-    params.active = true
-    params.sigcert = pk
-    params.entity = [id: entityDescriptor.id]
-    params.idp = [displayName: "test name", description:"test desc", scope:"test.com", crypto:[sig: true, enc:true], post:'http://identityProvider.test.com/SAML2/POST/SSO',
-                redirect:'http://identityProvider.test.com/SAML2/Redirect/SSO', artifact:'/SAML2/SOAP/ArtifactResolution', 'artifact-index':1]
-    params.aa = [create: true, displayName:"test name", description:"test desc", scope:"test.com", crypto:[sig: true, enc:true], attributeservice:[uri:"http://identityProvider.test.com/SAML2/SOAP/AttributeQuery"], attributes:[1, 2]]
-    params.contact = [email: contact.email, type:'technical']
-
-    when:
-    def (created, ret) = IdentityProviderService.create(params)
-
-    then:
-    !created
-
-        def identityProvider = ret.identityProvider
-        def attributeAuthority = ret.attributeAuthority
-
-    identityProvider.organization == organization
-    identityProvider.entityDescriptor == entityDescriptor
-    identityProvider.entityDescriptor.organization == organization
-
-    identityProvider.displayName == "test name"
-    identityProvider.description == "test desc"
-
-    identityProvider.keyDescriptors.size() == 1
-    identityProvider.keyDescriptors.toList().get(0).keyInfo.certificate.data == pk
-
-    identityProvider.singleSignOnServices.size() == 2
-
-    identityProvider.singleSignOnServices.contains(ret.httpPost)
-    ret.httpPost.location == "http://identityProvider.test.com/SAML2/POST/SSO"
-
-
-    identityProvider.singleSignOnServices.contains(ret.httpRedirect)
-    ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
-
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "/SAML2/SOAP/ArtifactResolution"
-    ret.soapArtifact.errors.getErrorCount() == 1
-    ret.soapArtifact.errors.getFieldError('location').code == 'url.invalid'
-
-
-    attributeAuthority.organization == organization
-    attributeAuthority.entityDescriptor == entityDescriptor
-    attributeAuthority.collaborator == null
-
-  }
-
-  def "Create fails when IDPSSODescriptor artifact endpoint not supplied"() {
-    setup:
-    setupBindings()
-    setupCrypto()
-
-    def saml2Prot = SamlURI.build(uri:'urn:oasis:names:tc:SAML:2.0:protocol')
-    def organization = Organization.build()
-    def entityDescriptor = EntityDescriptor.build(organization:organization)
-    def attr1 = Attribute.build()
-    def attr2 = Attribute.build()
-    def pk = loadPK()
-    def contact = Contact.build(organization: organization)
-    def ct = new ContactType(name:'technical', displayName:'Technical', description: 'Technical contacts').save()
-
-    params.organization = [id: organization.id]
-    params.active = true
-    params.sigcert = pk
-    params.entity = [id: entityDescriptor.id]
-    params.idp = [displayName: "test name", description:"test desc", scope:"test.com", crypto:[sig: true, enc:true], post:'http://identityProvider.test.com/SAML2/POST/SSO',
-                redirect:'http://identityProvider.test.com/SAML2/Redirect/SSO']
-    params.aa = [create: true, displayName:"test name", description:"test desc", scope:"test.com", crypto:[sig: true, enc:true], attributeservice:[uri:"http://identityProvider.test.com/SAML2/SOAP/AttributeQuery"], attributes:[1, 2]]
-    params.contact = [email: contact.email, type:'technical']
-
-    when:
-    def (created, ret) = IdentityProviderService.create(params)
-
-    then:
-    !created
-
-        def identityProvider = ret.identityProvider
-        def attributeAuthority = ret.attributeAuthority
-
-    identityProvider.organization == organization
-    identityProvider.entityDescriptor == entityDescriptor
-    identityProvider.entityDescriptor.organization == organization
-
-    identityProvider.displayName == "test name"
-    identityProvider.description == "test desc"
-
-    identityProvider.keyDescriptors.size() == 1
-    identityProvider.keyDescriptors.toList().get(0).keyInfo.certificate.data == pk
-
-    identityProvider.singleSignOnServices.size() == 2
-
-    identityProvider.singleSignOnServices.contains(ret.httpPost)
-    ret.httpPost.location == "http://identityProvider.test.com/SAML2/POST/SSO"
-
-
-    identityProvider.singleSignOnServices.contains(ret.httpRedirect)
-    ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
-
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == null
-    ret.soapArtifact.hasErrors()
-    ret.soapArtifact.errors.getFieldError('location').code == 'nullable'
-    identityProvider.hasErrors()
-    identityProvider.errors.getFieldError('artifactResolutionServices[0].location').code == 'nullable'
+    identityProvider.artifactResolutionServices == null
 
     attributeAuthority.organization == organization
     attributeAuthority.entityDescriptor == entityDescriptor
@@ -936,55 +781,14 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
       sso2.location == "http://identityProvider.test.com/SAML2/POST/SSO"
     }
 
-    identityProvider.artifactResolutionServices.size() == 1
-    identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
-  }
+    identityProvider.artifactResolutionServices == null
 
-  def "Backchannel crypto is correctly registered"() {
-    setup:
-    setupBindings()
-    setupCrypto()
-
-    def saml2Prot = SamlURI.build(uri:'urn:oasis:names:tc:SAML:2.0:protocol')
-    def organization = Organization.build()
-    def entityDescriptor = EntityDescriptor.build(organization:organization)
-    def attr1 = Attribute.build()
-    def attr2 = Attribute.build()
-    def pk = loadPK()
-    def backPK = loadBackPK();
-    def contact = Contact.build(organization: organization)
-    def ct = new ContactType(name:'technical', displayName:'Technical', description: 'Technical contacts').save()
-
-    params.organization = [id: organization.id]
-    params.active = true
-    params.sigcert = pk
-    params.bccert = backPK
-    params.entity = [id: entityDescriptor.id]
-    params.idp = [displayName:"test name", description:"test desc", scope:"test.com", crypto:[sig: true, bc:true], post:'http://identityProvider.test.com/SAML2/POST/SSO',
-                redirect:'http://identityProvider.test.com/SAML2/Redirect/SSO', artifact:'http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution', 'artifact-index':1]
-    params.aa = [create: false]
-    params.contact = [email: contact.email, type:'technical']
-
-    def wfProcessName, wfDescription, wfPriority, wfParams
-
-    when:
-    WorkflowProcessService.metaClass.initiate =  { String processName, String instanceDescription, ProcessPriority priority, Map params ->
-      wfProcessName = processName
-      wfDescription = instanceDescription
-      wfPriority = priority
-      wfParams = params
-      [true, [:]]
-    }
-    WorkflowProcessService.metaClass.run = { def processInstance -> }
-    def (created, ret) = IdentityProviderService.create(params)
-
-    then:
-    created
-
-    def identityProvider = ret.identityProvider
-    identityProvider.keyDescriptors.size() == 2
-    identityProvider.keyDescriptors.toList().sort().get(0).keyInfo.certificate.data !=
-    identityProvider.keyDescriptors.toList().sort().get(1).keyInfo.certificate.data
+    wfProcessName == "idpssodescriptor_create"
+    wfPriority == ProcessPriority.MEDIUM
+    wfParams.size() == 5
+    wfParams.creator == "${contact.id}"
+    wfParams.identityProvider == "${identityProvider.id}"
+    wfParams.organization == "${organization.id}"
   }
 
   def "Encryption crypto is correctly registered"() {
@@ -1097,8 +901,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
       sso2.location == "http://identityProvider.test.com/SAML2/POST/SSO"
     }
 
-    identityProvider.artifactResolutionServices.size() == 1
-    identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     wfProcessName == "idpssodescriptor_create"
 
@@ -1170,8 +973,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
       sso2.location == "http://identityProvider.test.com/SAML2/POST/SSO"
     }
 
-    identityProvider.artifactResolutionServices.size() == 1
-    identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     wfProcessName == "idpssodescriptor_create"
 
@@ -1180,64 +982,6 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     wfParams.creator == "${contact.id}"
     wfParams.identityProvider == "${identityProvider.id}"
     wfParams.organization == "${organization.id}"
-  }
-
-  def "Create fails when AttributeAuthorityDescriptor fails to meet constraints"() {
-    setup:
-    setupBindings()
-    setupCrypto()
-
-    def saml2Prot = SamlURI.build(uri:'urn:oasis:names:tc:SAML:2.0:protocol')
-    def organization = Organization.build()
-    def entityDescriptor = EntityDescriptor.build(organization:organization)
-    def attr1 = Attribute.build()
-    def attr2 = Attribute.build()
-    def pk = loadPK()
-    def contact = Contact.build(organization: organization)
-    def ct = new ContactType(name:'technical', displayName:'Technical', description: 'Technical contacts').save()
-
-    params.organization = [id: organization.id]
-    params.active = true
-    params.sigcert = pk
-    params.entity = [id: entityDescriptor.id]
-    params.idp = [displayName:"test name", description:"test desc", scope:"test.com", crypto:[sig: true, enc:true], post:'http://identityProvider.test.com/SAML2/POST/SSO',
-                redirect:'http://identityProvider.test.com/SAML2/Redirect/SSO', artifact:'http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution', 'artifact-index':1]
-    params.aa = [create: true, crypto:[sig: true, enc:true], attributeservice:[uri:"abcd"], attributes:[1, 2]]
-    params.contact = [email: contact.email, type:'technical']
-
-    when:
-    def (created, ret) = IdentityProviderService.create(params)
-
-    then:
-    !created
-
-        def identityProvider = ret.identityProvider
-        def attributeAuthority = ret.attributeAuthority
-
-    identityProvider.organization == organization
-    identityProvider.entityDescriptor == entityDescriptor
-    identityProvider.entityDescriptor.organization == organization
-
-    identityProvider.displayName == "test name"
-    identityProvider.description == "test desc"
-    identityProvider.keyDescriptors.size() == 1
-    identityProvider.keyDescriptors.toList().get(0).keyInfo.certificate.data == pk
-
-    identityProvider.singleSignOnServices.size() == 2
-
-    identityProvider.singleSignOnServices.contains(ret.httpPost)
-    ret.httpPost.location == "http://identityProvider.test.com/SAML2/POST/SSO"
-
-
-    identityProvider.singleSignOnServices.contains(ret.httpRedirect)
-    ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
-
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
-
-    attributeAuthority.displayName == "test name"
   }
 
   def "Create fails when invalid existing EnityDescriptor provided"() {
@@ -1289,15 +1033,11 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     identityProvider.singleSignOnServices.contains(ret.httpRedirect)
     ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     attributeAuthority.organization == organization
     attributeAuthority.entityDescriptor.hasErrors()
         attributeAuthority.collaborator == null
-
   }
 
   def "Create fails when EnityDescriptor does not meet constraints"() {
@@ -1348,15 +1088,11 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     identityProvider.singleSignOnServices.contains(ret.httpRedirect)
     ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     attributeAuthority.organization == organization
     attributeAuthority.entityDescriptor.hasErrors()
     attributeAuthority.collaborator == null
-
   }
 
   def "Create fails when invalid Organization provided"() {
@@ -1408,10 +1144,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
     identityProvider.singleSignOnServices.contains(ret.httpRedirect)
     ret.httpRedirect.location == "http://identityProvider.test.com/SAML2/Redirect/SSO"
 
-    identityProvider.artifactResolutionServices.size() == 1
-
-    identityProvider.artifactResolutionServices.contains(ret.soapArtifact)
-    ret.soapArtifact.location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     attributeAuthority.organization == null
     attributeAuthority.entityDescriptor.hasErrors()
@@ -1485,8 +1218,7 @@ class IdentityProviderServiceSpec extends IntegrationSpec {
         sso2.location == "http://identityProvider.test.com/SAML2/POST/SSO"
     }
 
-    identityProvider.artifactResolutionServices.size() == 1
-    identityProvider.artifactResolutionServices.toList().get(0).location == "http://identityProvider.test.com/SAML2/SOAP/ArtifactResolution"
+    identityProvider.artifactResolutionServices == null
 
     identityProvider.attributes != null
     identityProvider.attributes.size() == 2


### PR DESCRIPTION
Whilst the use of back channel endpoints (e.g. port 8443) was common in earlier deployments of the IdP it is recognized in more recent times that this is not actually necessary and that it can lead to security issues when enabled without a specific need.

Should a newly created IdP have some specific need for 8443 support these endpoints can still be manually provided once registration has been completed.