### PR TITLE
Export: sort dicts in structureAsJson() methods

### DIFF
--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/AttributeAuthorityDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/AttributeAuthorityDescriptor.groovy
@@ -57,8 +57,8 @@ class AttributeAuthorityDescriptor extends RoleDescriptor {
 		  							 name this.organization.displayName }
 
 		  if(!collaborator)	{
-				contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }
-				monitors this.monitors.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], url: it.url, node: it.node ?: '', enabled: it.enabled, check_period: it.checkPeriod] }
+				contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }?.sort{it.id}
+				monitors this.monitors.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], url: it.url, node: it.node ?: '', enabled: it.enabled, check_period: it.checkPeriod] }?.sort{it.id}
 		  }
 
 			active this.active
@@ -67,7 +67,7 @@ class AttributeAuthorityDescriptor extends RoleDescriptor {
 			functioning this.functioning()
 			created_at dateCreated
 			updated_at lastUpdated
-			administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }
+			administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }?.sort{it.id}
 
 			saml {
 				entity {
@@ -76,18 +76,18 @@ class AttributeAuthorityDescriptor extends RoleDescriptor {
 				}
 				if(collaborator) {
 					extract_metadata_from_idp_sso_descriptor true
-					attribute_services attributeServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
+					attribute_services attributeServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
 					idp_sso_descriptor collaborator?.id
 				} else {
 					extract_metadata_from_idp_sso_descriptor false
 					scope scope
-					attribute_services attributeServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
-					assertion_id_request_services assertionIDRequestServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
-					name_id_formats nameIDFormats.collect{ [id: it.id, uri: it.uri]}
-					attribute_profiles attributeProfiles.collect { [id:it.id, uri: it.uri]}
+					attribute_services attributeServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
+					assertion_id_request_services assertionIDRequestServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
+					name_id_formats nameIDFormats.collect{ [id: it.id, uri: it.uri]}?.sort{it.id}
+					attribute_profiles attributeProfiles.collect { [id:it.id, uri: it.uri]}?.sort{it.id}
 					attributes attributes.collect { [id:it.base.id, name: it.base.name, specification: it.base.specificationRequired,
-																					 values: it.values.collect { [value: it.value, approved: it.approved] }
-																				] }
+																					 values: it.values.collect { [value: it.value, approved: it.approved] }?.sort{it.value}
+																				] }?.sort{it.id}
 					role_descriptor super.structureAsJson()
 				}
 			}

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/EntityDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/EntityDescriptor.groovy
@@ -97,7 +97,7 @@ class EntityDescriptor extends Descriptor  {
 		  entity_id entityID
 		  organization { id this.organization.id
 		  							 name this.organization.displayName }
-		  contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }
+		  contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }?.sort{it.id}
 
 		  active active
 		  archived archived
@@ -110,10 +110,10 @@ class EntityDescriptor extends Descriptor  {
 		  	sp_sso_descriptor_only this.holdsSPOnly()
 			  empty this.empty()
 		  	extensions extensions ?: ''
-		  	identity_providers idpDescriptors.collect { [id: it.id, functioning: it.functioning()] }
-		  	service_providers spDescriptors.collect { [id: it.id, functioning: it.functioning()] }
-		  	attribute_authorities attributeAuthorityDescriptors.collect { [id: it.id, functioning: it.functioning()] }
-		  	additional_metadata_locations additionalMetadataLocations.collect{ [uri: it.uri, namespace: it.namespace]}
+		  	identity_providers idpDescriptors.collect { [id: it.id, functioning: it.functioning()] }?.sort{it.id}
+		  	service_providers spDescriptors.collect { [id: it.id, functioning: it.functioning()] }?.sort{it.id}
+		  	attribute_authorities attributeAuthorityDescriptors.collect { [id: it.id, functioning: it.functioning()] }?.sort{it.id}
+		  	additional_metadata_locations additionalMetadataLocations.collect{ [uri: it.uri, namespace: it.namespace]}?.sort{it.uri}
 		  }
 		}
 	}

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/IDPSSODescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/IDPSSODescriptor.groovy
@@ -95,8 +95,8 @@ class IDPSSODescriptor extends SSODescriptor  {
 		  organization { id this.organization.id
 		  							 name this.organization.displayName }
 
-			contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }
-			monitors this.monitors.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], url: it.url, node: it.node ?: '', enabled: it.enabled, check_period: it.checkPeriod] }
+			contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }?.sort{it.id}
+			monitors this.monitors.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], url: it.url, node: it.node ?: '', enabled: it.enabled, check_period: it.checkPeriod] }?.sort{it.id}
 
 		  active this.active
 		  archived this.archived
@@ -105,7 +105,7 @@ class IDPSSODescriptor extends SSODescriptor  {
 		  utilises_attribute_filters autoAcceptServices
 		  created_at dateCreated
 		  updated_at lastUpdated
-		  administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }
+		  administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }?.sort{it.id}
 			saml {
 				entity {
 					id entityDescriptor.id
@@ -114,13 +114,13 @@ class IDPSSODescriptor extends SSODescriptor  {
 				attribute_authority_descriptor collaborator?.id
 				scope scope
 				authnrequests_signed wantAuthnRequestsSigned
-				single_sign_on_services singleSignOnServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
-				name_id_mapping_services nameIDMappingServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
-				assertion_id_request_services assertionIDRequestServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
-				attribute_profiles attributeProfiles.collect { [id:it.id, uri: it.uri]}
+				single_sign_on_services singleSignOnServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
+				name_id_mapping_services nameIDMappingServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
+				assertion_id_request_services assertionIDRequestServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
+				attribute_profiles attributeProfiles.collect { [id:it.id, uri: it.uri]}?.sort{it.id}
 				attributes attributes.collect { [id:it.base.id, name: it.base.name, specification: it.base.specificationRequired,
-																				 values: it.values.collect { [value: it.value, approved: it.approved] }
-																			] }
+																				 values: it.values.collect { [value: it.value, approved: it.approved] }?.sort{it.value}
+																			] }?.sort{it.id}
 				sso_descriptor super.structureAsJson()
 			}
 		}

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/Organization.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/Organization.groovy
@@ -105,28 +105,28 @@ class Organization  {	// Also called a participant in AAF land
 		  url this.url
 		  logo_url this.logoURL ?: ''
 		  lang this.lang
-		  contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }
+		  contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }?.sort{it.id}
 		  active this.active
 		  archived this.archived
 		  approved this.approved
 		  functioning this.functioning()
 		  types {
 		    primary this.primary.id
-		    secondary this.types.collect { it.id }
-		    suspensions this.suspensions.collect { it.id }
+		    secondary this.types.collect { it.id }?.sort{it.id}
+		    suspensions this.suspensions.collect { it.id }?.sort{it.id}
 		  }
-		  sponsors this.sponsors.collect { it.id }
-		  affiliates this.affiliates.collect { it.id }
+		  sponsors this.sponsors.collect { it.id }?.sort{it.id}
+		  affiliates this.affiliates.collect { it.id }?.sort{it.id}
 		  saml {
-		  	entity_descriptors entityDescriptors.collect { [id: it.id, entity_id: it.entityID, functioning: it.functioning()]}
-		    identity_providers identityProviders.collect { [id: it.id, entity: [id: it.entityDescriptor.id, entity_id: it.entityDescriptor.entityID], functioning: it.functioning()] }
-		    service_providers serviceProviders.collect { [id: it.id, entity: [id: it.entityDescriptor.id, entity_id: it.entityDescriptor.entityID], functioning: it.functioning()] }
-		    attribute_authorities attributeAuthorities.collect { [id: it.id, entity: [id: it.entityDescriptor.id, entity_id: it.entityDescriptor.entityID], functioning: it.functioning()] }
+		  	entity_descriptors entityDescriptors.collect { [id: it.id, entity_id: it.entityID, functioning: it.functioning()]}?.sort{it.id}
+		    identity_providers identityProviders.collect { [id: it.id, entity: [id: it.entityDescriptor.id, entity_id: it.entityDescriptor.entityID], functioning: it.functioning()] }?.sort{it.id}
+		    service_providers serviceProviders.collect { [id: it.id, entity: [id: it.entityDescriptor.id, entity_id: it.entityDescriptor.entityID], functioning: it.functioning()] }?.sort{it.id}
+		    attribute_authorities attributeAuthorities.collect { [id: it.id, entity: [id: it.entityDescriptor.id, entity_id: it.entityDescriptor.entityID], functioning: it.functioning()] }?.sort{it.id}
 		    extensions this.extensions ?: ''
 		  }
 		  created_at dateCreated
 		  updated_at lastUpdated
-		  administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }
+		  administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }?.sort{it.id}
 		}
 		json.content
 	}

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/RoleDescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/RoleDescriptor.groovy
@@ -62,7 +62,7 @@ abstract class RoleDescriptor extends Descriptor {
 	def structureAsJson() {
     def json = new groovy.json.JsonBuilder()
     json {
-    	protocol_support_enumerations protocolSupportEnumerations.collect{ [id: it.id, uri: it.uri]}
+    	protocol_support_enumerations protocolSupportEnumerations.collect{ [id: it.id, uri: it.uri]}?.sort{it.id}
     	key_descriptors keyDescriptors.collect {
     										[  id: it.id, type: it.keyType, disabled: it.disabled,
 	    										 encryption_method: [ algorithm: it.encryptionMethod?.algorithm ?: '',
@@ -77,8 +77,8 @@ abstract class RoleDescriptor extends Descriptor {
 																			  ]
 													 ],
     									  ]
-    									}
-      contact_people this.contacts.findAll{it.functioning()}.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], contact: [id: it.contact.id]] }
+    									}?.sort{it.id}
+      contact_people this.contacts.findAll{it.functioning()}.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], contact: [id: it.contact.id]] }?.sort{it.id}
       error_url errorURL ?:''
       extensions extensions ?:''
     }

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/SPSSODescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/SPSSODescriptor.groovy
@@ -86,10 +86,10 @@ class SPSSODescriptor extends SSODescriptor {
 		  	maintenance serviceDescription.maintenance ?: ''
 		  }
 
-		  categories serviceCategories.collect { [id: it.id, name: it.name] }
+		  categories serviceCategories.collect { [id: it.id, name: it.name] }?.sort{it.id}
 
-		  contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }
-		  monitors this.monitors.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], url: it.url, node: it.node ?: '', enabled: it.enabled, check_period: it.checkPeriod] }
+		  contacts this.contacts.collect { [id: it.id, type: [id: it.type.id, name: it.type.name]] }?.sort{it.id}
+		  monitors this.monitors.collect { [id: it.id, type: [id: it.type.id, name: it.type.name], url: it.url, node: it.node ?: '', enabled: it.enabled, check_period: it.checkPeriod] }?.sort{it.id}
 
 		  active this.active
 		  archived this.archived
@@ -98,7 +98,7 @@ class SPSSODescriptor extends SSODescriptor {
 		  reporting this.reporting
 		  created_at dateCreated
 		  updated_at lastUpdated
-		  administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }
+		  administrators adminRole?.subjects.collect { [id: it.id, principal: it.sharedToken] }?.sort{it.id}
 			saml {
 				entity {
 					id entityDescriptor.id
@@ -112,11 +112,11 @@ class SPSSODescriptor extends SSODescriptor {
 																			descriptions: it.serviceDescriptions,
 																			attributes: it.requestedAttributes.collect { [id:it.base.id, name: it.base.name, specification: it.base.specificationRequired,
 																									reason: it.reasoning, is_required: it.isRequired,  approved: it.approved,
-																									values: it.values.collect { [value: it.value, approved: it.approved] }
-																									] }
-																			] }
-				assertion_consumer_services assertionConsumerServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning(), index: it.index, is_default: it.isDefault ]}
-      	discovery_response_services discoveryResponseServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning(), index: it.index, is_default: it.isDefault ]}
+																									values: it.values.collect { [value: it.value, approved: it.approved] }?.sort{it.value}
+																									] }?.sort{it.id}
+																			] }?.sort{it.id}
+				assertion_consumer_services assertionConsumerServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning(), index: it.index, is_default: it.isDefault ]}?.sort{it.id}
+      	discovery_response_services discoveryResponseServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning(), index: it.index, is_default: it.isDefault ]}?.sort{it.id}
 				sso_descriptor super.structureAsJson()
 			}
 		}

--- a/app/plugins/base/grails-app/domain/aaf/fr/foundation/SSODescriptor.groovy
+++ b/app/plugins/base/grails-app/domain/aaf/fr/foundation/SSODescriptor.groovy
@@ -30,10 +30,10 @@ abstract class SSODescriptor extends RoleDescriptor  {
     def json = new groovy.json.JsonBuilder()
     json {
       role_descriptor super.structureAsJson()
-      name_id_formats nameIDFormats.collect { [id:it.id, uri: it.uri]}
-      artifact_resolution_services artifactResolutionServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning(), index: it.index, is_default: it.isDefault ]}
-      single_logout_services singleLogoutServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
-      manage_nameid_services manageNameIDServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}
+      name_id_formats nameIDFormats.collect { [id:it.id, uri: it.uri]}?.sort{it.id}
+      artifact_resolution_services artifactResolutionServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning(), index: it.index, is_default: it.isDefault ]}?.sort{it.id}
+      single_logout_services singleLogoutServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
+      manage_nameid_services manageNameIDServices.collect { [id: it.id, location: it.location, binding: [id: it.binding.id, uri: it.binding.uri], functioning: it.functioning() ]}?.sort{it.id}
     }
 
     json.content


### PR DESCRIPTION
... to avoid spurious changes in exported data (and further on in consuming applications like SAML Service)

Hi @bradleybeddoes , is this something you'd be willing to merge?

When watching SAML Service closely, I saw it was generating a lot of spurious changes in metadata ingested from FR - which I could track to changing order of certificates.

When I checked the export API, it was leaving lots of dicts in random order.

I have added a `sort` to every `collect` in the `structureAsJson()` methods and the export data is now stable across multiple invocations.

All tests (in `base` where the changes are done) pass, and I am running this on a live deployment (so far DEV, but being exercises by other services).  All works well.

Please let me know if interested to mere...

Cheers,
Vlad