### PR TITLE
Branding: remove all remaining references to Zenbox

### DIFF
--- a/branding/grails-app/views/layouts/error.gsp
+++ b/branding/grails-app/views/layouts/error.gsp
@@ -28,7 +28,7 @@
               <li class="${controllerName == 'dashboard' ? 'directactive':''}">
                 <g:link controller="dashboard"><g:message encodeAs="HTML"  code="fr.branding.nav.dashboard" default="Dashboard"/></g:link>
               </li>
-              <li><a style="color: #fff;" href="#" onClick="script: Zenbox.show(); return false;"><g:message encodeAs="HTML"  code="fr.branding.nav.support" default="Support"/></a></li>
+              <li><a style="color: #fff;" href="https://aaf.edu.au/support/"><g:message encodeAs="HTML"  code="fr.branding.nav.support" default="Support"/></a></li>
             </ul>
           </div>
         </div>

--- a/branding/grails-app/views/templates/_frfooter.gsp
+++ b/branding/grails-app/views/templates/_frfooter.gsp
@@ -4,7 +4,3 @@
 Federation Registry <strong>version <g:meta name="app.version"/></strong>
 <br>
 Developed by the <a href="http://www.aaf.edu.au">Australian Access Federation</a>.
-
-<r:script>
-  if(typeof Zenbox!=="undefined"){Zenbox.init({dropboxID:"6875",url:"australianaccessfederation.zendesk.com",tabID:"support",hide_tab:true})}
-</r:script>


### PR DESCRIPTION
Hi @bradleybeddoes ,

I came across this while working on the Grails upgrade.

I found that the error.gsp template used by all error handlers was still using Support link pointing to Zenbox - which, with the ZenBox code removed, would do nothing.

Unfortunate to break the Support link on an Error page... otherwise, I'd have followed your path of no more changes to FR ... but this looks as worth fixing to me.

So two minor changes:
* remove dead code from _frfooter.gsp (inactive as Zenbox is no longer loaded)
* fix Support link on error pages - would attempt to use ZenBox and do nothing.

Please let me know if happy to merge this into your code.

Cheers,
Vlad